### PR TITLE
Mode is not passed to the method from the datasets:load method

### DIFF
--- a/lib/gooddata/models/project.rb
+++ b/lib/gooddata/models/project.rb
@@ -116,7 +116,7 @@ module GoodData
       Model.add_schema schema, self
     end
 
-    def upload(file, schema, mode)
+    def upload(file, schema, mode = "FULL")
       schema.upload file, self, mode
     end
 


### PR DESCRIPTION
Method call fails with:

/Library/Ruby/Gems/1.8/gems/gooddata-0.3.0/lib/gooddata/commands/datasets.rb:89:in `upload': wrong number of arguments (2 for 3) (ArgumentError)
    from /Library/Ruby/Gems/1.8/gems/gooddata-0.3.0/lib/gooddata/commands/datasets.rb:89:in`load'
    from /Library/Ruby/Gems/1.8/gems/gooddata-0.3.0/lib/gooddata/commands/datasets.rb:100:in `with_project'
    from /Library/Ruby/Gems/1.8/gems/gooddata-0.3.0/lib/gooddata/commands/datasets.rb:83:in`load'
    from /Library/Ruby/Gems/1.8/gems/gooddata-0.3.0/lib/gooddata/command.rb:40:in `send'
    from /Library/Ruby/Gems/1.8/gems/gooddata-0.3.0/lib/gooddata/command.rb:40:in`run_internal'
    from /Library/Ruby/Gems/1.8/gems/gooddata-0.3.0/lib/gooddata/command.rb:16:in `run'

Added mode = full default to the upload method in the projects model.
