### PR TITLE
handling of 204

### DIFF
--- a/lib/gooddata/connection.rb
+++ b/lib/gooddata/connection.rb
@@ -311,6 +311,9 @@ module GoodData
         elsif response.headers[:content_length].to_s == '0'
           result = nil
           GoodData.logger.debug "Response: Empty response possibly 204"
+        elsif response.code == 204
+          result = nil
+          GoodData.logger.debug "Response: 204 no content"
         else
           raise "Unsupported response content type '%s':\n%s" % [ content_type, response.to_str[0..127] ]
         end


### PR DESCRIPTION
Next release has a new behavior for many resources, now 204 response has missing content_length and content_type, so the tool fails. This commit adds three lines to handle this issue.
