### PR TITLE
Adding dry_run for migrate_datasets for getting the MAQL chunks. Migrate...

### DIFF
--- a/lib/gooddata/models/from_wire.rb
+++ b/lib/gooddata/models/from_wire.rb
@@ -90,7 +90,7 @@ module GoodData
           d[:type] = :date_dimension
           # d[:urn] = :date_dimension
           d[:name] = stuff['dateDimension']['name']
-          d[:title] = stuff['dateDimension']['title'] if stuff['dateDimension']['title'] != stuff['dateDimension']['title'].titleize
+          d[:title] = stuff['dateDimension']['title'] if stuff['dateDimension']['title'] != d[:name].titleize
         end
       end
 

--- a/lib/gooddata/models/model.rb
+++ b/lib/gooddata/models/model.rb
@@ -29,7 +29,7 @@ module GoodData
         item[:title] || item[:name].titleize
       end
 
-      def identifier_for(dataset, column = nil, column2 = nil)
+      def identifier_for(dataset, column = nil, column2 = nil) # rubocop:disable UnusedMethodArgument
         return "dataset.#{dataset[:name]}" if column.nil?
         column = DatasetBlueprint.find_column_by_name(dataset, column) if column.is_a?(String)
         case column[:type].to_sym
@@ -46,11 +46,15 @@ module GoodData
         when :primary_label
           "label.#{dataset[:name]}.#{column[:name]}"
         when :label
-          "label.#{dataset[:name]}.#{column2[:name]}.#{column[:name]}"
+          "label.#{dataset[:name]}.#{column[:reference]}.#{column[:name]}"
         when :date_ref
           "#{dataset[:name]}.date.mdyy"
         when :dataset
           "dataset.#{dataset[:name]}"
+        when :date
+          'DATE'
+        when :reference
+          'REF'
         else
           fail "Unknown type #{column[:type].to_sym}"
         end


### PR DESCRIPTION
... does not crash when chunks are nil. The title is based on identifier now.