### PR TITLE
BUGFIX: fix error reporting for ETL/pull

### DIFF
--- a/lib/gooddata/rest/connection.rb
+++ b/lib/gooddata/rest/connection.rb
@@ -188,7 +188,7 @@ module GoodData
             :url => url
           }.merge(cookies)
 
-          if where.is_a?(IO)
+          if where.is_a?(IO) || where.is_a?(StringIO)
             RestClient::Request.execute(raw) do |chunk, _x, response|
               if response.code.to_s != '200'
                 fail ArgumentError, "Error downloading #{url}. Got response: #{response.code} #{response} #{response.body}"


### PR DESCRIPTION
GoodData::Model.upload_data (line 130) tries to fetch upload_status.json in case of failed ETL/pull for diagnostics, but it passes in a StringIO, not IO / file path...