### PR TITLE
BIA-32

### DIFF
--- a/lib/gooddata/rest/client.rb
+++ b/lib/gooddata/rest/client.rb
@@ -20,6 +20,8 @@ module GoodData
       # Constants
       #################################
       DEFAULT_CONNECTION_IMPLEMENTATION = GoodData::Rest::Connection
+      DEFAULT_SLEEP_INTERVAL = 10
+      DEFAULT_POLL_TIME_LIMIT = 5 * 60 * 60 # 5 hours
 
       #################################
       # Class variables
@@ -236,7 +238,7 @@ module GoodData
         fail ArgumentError, 'Wrong :project specified' if project.nil?
 
         url = project.links['uploads']
-        raise 'Project WebDAV not supported in this Data Center' unless url
+        fail 'Project WebDAV not supported in this Data Center' unless url
         url
       end
 
@@ -262,17 +264,13 @@ module GoodData
       # @return [Hash] Result of polling
       def poll_on_code(link, options = {})
         code = options[:code] || 202
-        sleep_interval = options[:sleep_interval] || DEFAULT_SLEEP_INTERVAL
-        response = get(link, :process => false)
+        process = options[:process]
 
-        while response.code == code
-          sleep sleep_interval
-          GoodData::Rest::Client.retryable(:tries => 3, :refresh_token => proc { connection.refresh_token }) do
-            sleep sleep_interval
-            response = get(link, :process => false)
-          end
+        response = poll_on_response(link, options.merge(:process => false)) do |resp|
+          resp.code == code
         end
-        if options[:process] == false
+
+        if process == false
           response
         else
           get(link)
@@ -290,12 +288,23 @@ module GoodData
       # @return [Hash] Result of polling
       def poll_on_response(link, options = {}, &bl)
         sleep_interval = options[:sleep_interval] || DEFAULT_SLEEP_INTERVAL
-        response = get(link)
+        time_limit = options[:time_limit] || DEFAULT_POLL_TIME_LIMIT
+
+        # by default the response is processed
+        process = options[:process]
+
+        # get the first status and start the timer
+        response = get(link, :process => process)
+        poll_start = Time.now
+
         while bl.call(response)
+          if time_limit && (Time.now - poll_start > time_limit)
+            fail "The time limit #{time_limit} secs for polling on #{link} is over"
+          end
           sleep sleep_interval
           GoodData::Rest::Client.retryable(:tries => 3, :refresh_token => proc { connection.refresh_token }) do
             sleep sleep_interval
-            response = get(link)
+            response = get(link, :process => process)
           end
         end
         response


### PR DESCRIPTION
  - added :time_limit param, default to 5 hours, after that an exception is raised
  - slight refactor, so that the polling is done on one place
  - poll funcitons on rest.rb now call client poll funcitons.
  - not propagating the options of high level functions (like upload_data) to poll_on_response / poll_on_code .. so the time limit option can only be used when calling poll directly