### PR TITLE
Ignore doc subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ tmtags
 ## PROJECT::GENERAL
 .bundle
 coverage
-rdoc
+/rdoc
+/doc
 pkg
 
 ## PROJECT::SPECIFIC


### PR DESCRIPTION
The changes in the `.gitignore` file are:
* ignore the default rdoc's output folder `doc`, to avoid its accidental
committing
* update the pattern to match only direct subdirectories, as `/rdoc` and
`/doc`