### PR TITLE
Add guard-rspec for automated spec runs

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,5 @@
+clearing :on
+
+guard :rspec, cmd: 'bundle exec rspec' do
+  watch(%r{^spec/.+_spec\.rb$})
+end

--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -35,6 +35,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard-rspec', '~> 0.1'
   s.add_development_dependency 'ZenTest', '~> 4.10', '>= 4.11.0'
   s.add_development_dependency 'coveralls', '~> 0.7', '>= 0.7.0'
+  s.add_development_dependency 'guard', '~> 2'
+  s.add_development_dependency 'guard-rspec', '~> 4'
 
   s.add_development_dependency 'debase' if !ENV['TRAVIS_BUILD'] && RUBY_VERSION >= '2.0.0'
   s.add_development_dependency 'ruby-debug-ide' if !ENV['TRAVIS_BUILD'] && RUBY_VERSION >= '2.0.0'


### PR DESCRIPTION
From now on, run:
```
$ bundle exec guard
```
and work (edit and save) your spec files, and see the results immediately.