### PR TITLE
Fixed 'No :client specified' when exporting a report

### DIFF
--- a/lib/gooddata/models/metadata/report.rb
+++ b/lib/gooddata/models/metadata/report.rb
@@ -122,7 +122,7 @@ module GoodData
     def export(format)
       result = client.post('/gdc/xtab2/executor3', 'report_req' => { 'report' => uri })
       result1 = client.post('/gdc/exporter/executor', :result_req => { :format => format, :result => result })
-      GoodData.poll_on_code(result1['uri'], process: false)
+      client.poll_on_code(result1['uri'], process: false)
     end
 
     # Returns the newest (current version) report definition uri


### PR DESCRIPTION
I was getting `gooddata-0.6.18/lib/gooddata/core/rest.rb:124:in 'poll_on_code': No :client specified (ArgumentError)` when running the following code.

```ruby
GoodData.with_connection(username, password) do |client|
	report = client.projects(PROJECT_ID).reports(REPORT_ID).export :csv
	File.open('report.csv', 'w').puts(report)
end
```

The change in the PR fixed the issue for me.  Thought you might want to know about it.