### PR TITLE
Typo

### DIFF
--- a/lib/gooddata/models/metadata/label.rb
+++ b/lib/gooddata/models/metadata/label.rb
@@ -63,7 +63,7 @@ module GoodData
 
           # Implementation of polling is based on
           # https://opengrok.intgdc.com/source/xref/gdc-backend/src/test/java/com/gooddata/service/dao/ValidElementsDaoTest.java
-          status_url = result['uri']
+          status_url = results['uri']
           if status_url
             results = client.poll_on_response(status_url) do |body|
               status = body['taskState']['status']


### PR DESCRIPTION
I think I found a typo - the status_uri (status for a polled lookup of a label's values) should come from result**s** not result.

I ran into a "no method 'result'" error when building a mandatory user filter.