### PR TITLE
[BIA-174] Schedule's reschedule must be nil by default

### DIFF
--- a/lib/gooddata/models/schedule.rb
+++ b/lib/gooddata/models/schedule.rb
@@ -27,7 +27,7 @@ module GoodData
         :timezone => nil,
         :params => {},
         :hiddenParams => {},
-        :reschedule => 0
+        :reschedule => nil
       }
     }
 


### PR DESCRIPTION
Setting reschedule to 0 by default is interpreted as "restart immediately", not as "restart never". And in https://jira.intgdc.com/browse/MSF-7703 this will be finally validated and will fail.