### PR TITLE
Fix anchor in commits

### DIFF
--- a/lib/templates/project/data/commits.csv
+++ b/lib/templates/project/data/commits.csv
@@ -1,4 +1,4 @@
-lines_changed,committed_on,dev_id,repo_id
-1,01/01/2014,1,1
-3,01/02/2014,2,2
-5,05/02/2014,3,1
+commit_id,lines_changed,committed_on,dev_id,repo_id
+1,1,01/01/2014,1,1
+2,3,01/02/2014,2,2
+3,5,05/02/2014,3,1

--- a/lib/templates/project/model/model.rb.erb
+++ b/lib/templates/project/model/model.rb.erb
@@ -12,6 +12,7 @@ GoodData::Model::ProjectBuilder.create("Test project") do |p|
   end
 
   p.add_dataset("commits") do |d|
+      d.add_anchor("commit_id")
       d.add_fact("lines_changed")
       d.add_date("committed_on", :dataset => "committed_on")
       d.add_reference('devs')


### PR DESCRIPTION
Unless I was getting:
error: Blueprint is invalid [{:type=>:no_anchor, :dataset=>"commits"}]