### PR TITLE
Add rake task for CI job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -165,6 +165,7 @@ namespace :test do
   end
 
   task :all => [:unit, :integration, :cop]
+  task :ci => [:unit, :integration]
 end
 
 desc 'Run all tests'


### PR DESCRIPTION
Run only the tests without rubocop. Rubocop will run in separate job.