### PR TITLE
Remove pry

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1,4 +1,4 @@
-# gooddata-ruby CLI 
+# gooddata-ruby CLI
 
 ## api
 
@@ -70,7 +70,7 @@ tomaskorcak@kx-mac:~/$ gooddata api get /gdc
 ### api info
 
 Info about the API version etc
-   
+
 ```
 tomaskorcak@kx-mac:~/$ gooddata api info
 GoodData API
@@ -223,10 +223,6 @@ tomaskorcak@kx-mac:~/$ gooddata -p tk6192gsnav58crp6o1ahsmtuniq8khb project invi
 Inviting tomas.korcak@gooddata.com, role: /gdc/projects/tk6192gsnav58crp6o1ahsmtuniq8khb/roles/2
 ```
 
-### project jack_in
-
-If you are in a gooddata project blueprint or if you provide a project id it will start an interactive session inside that project
-
 ### project list_users
 
 List users
@@ -373,7 +369,7 @@ drwxr-xr-x  31 tomaskorcak  staff  1054 Apr 22 14:10 ..
 -rw-r--r--   1 tomaskorcak  staff   103 Apr 22 14:10 brick.rb
 -rw-r--r--   1 tomaskorcak  staff   179 Apr 22 14:10 main.rb
 
-tomaskorcak@kx-mac:~/$ cat mybrick/brick.rb 
+tomaskorcak@kx-mac:~/$ cat mybrick/brick.rb
 class MyBrick < GoodData::Bricks::Brick
 
     def call(params)
@@ -382,7 +378,7 @@ class MyBrick < GoodData::Bricks::Brick
 
 end
 
-tomaskorcak@kx-mac:~/$ cat mybrick/main.rb 
+tomaskorcak@kx-mac:~/$ cat mybrick/main.rb
 require_relative '../../gooddata/bricks/bricks'
 
 require_relative './mybrick'

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -96,7 +96,7 @@ application.
 
 <a name="bundler"></a>
 ### bundler v1.11.2 (development)
-#### 
+####
 
 unknown manually approved
 
@@ -125,7 +125,7 @@ unknown manually approved
 ><cite>  2016-02-22</cite>
 
   >> puts "this is red".red
- 
+
   >> puts "this is red with a blue background (read: ugly)".red_on_blue
 
   >> puts "this is red with an underline".red.underline
@@ -306,7 +306,7 @@ Guard::RSpec automatically run your specs (much like autotest).
 
 <a href="http://opensource.org/licenses/mit-license">MIT</a> whitelisted
 
- HashDiff is a diff lib to compute the smallest difference between two hashes. 
+ HashDiff is a diff lib to compute the smallest difference between two hashes.
 
 <a name="hashie"></a>
 ### <a href="https://github.com/intridea/hashie">hashie</a> v3.4.3
@@ -523,10 +523,6 @@ Add parallel methods into Enumerable: pmap and peach
 <a href="http://opensource.org/licenses/mit-license">MIT</a> whitelisted
 
 A few useful extensions to core Ruby classes.
-
-<a name="pry"></a>
-### <a href="http://pryrepl.org">pry</a> v0.10.3
-#### An IRB alternative and runtime developer console
 
 <a href="http://opensource.org/licenses/mit-license">MIT</a> whitelisted
 
@@ -813,5 +809,3 @@ WebMock allows stubbing HTTP requests and setting expectations on HTTP requests.
 #### YARD plugin to list RSpec specifications inside documentation
 
 <a href="http://opensource.org/licenses/mit-license">MIT</a> whitelisted
-
-

--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -52,7 +52,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json', '~> 1.11', '>= 1.11.2'
   s.add_dependency 'parseconfig', '~> 1.0', '>= 1.0.6'
   s.add_dependency 'pmap', '~> 1.0', '>= 1.0.2'
-  s.add_dependency 'pry', '~> 0.10', '>= 0.10.3'
   s.add_dependency 'restforce', '~> 2.1', '>= 2.1.1'
   s.add_dependency 'rest-client', '~> 1.8', '>= 1.8.0'
   s.add_dependency 'rubyzip', '~> 1.1', '>= 1.1.7'

--- a/lib/gooddata/cli/commands/project_cmd.rb
+++ b/lib/gooddata/cli/commands/project_cmd.rb
@@ -16,29 +16,12 @@ module GoodData
     arg_name 'project_command'
 
     command :project do |c|
-      c.desc 'If you are in a gooddata project blueprint or if you provide a project id it will start an interactive session inside that project'
-      c.command :jack_in do |jack|
-        jack.action do |global_options, options, _args|
-          warn '[DEPRECATION] `gooddata project jack_in` is deprecated.  Please use `gooddata jack_in` instead.'
-          opts = options.merge(global_options)
-          GoodData::Command::Project.jack_in(opts)
-        end
-      end
-
       c.desc 'Shows users in project'
       c.command :users do |users|
         users.action do |global_options, options, _args|
           opts = options.merge(global_options)
           GoodData::Command::Project.list_users(opts)
         end
-      end
-    end
-
-    desc 'If you are in a gooddata project blueprint or if you provide a project id it will start an interactive session inside that project'
-    command :jack_in do |jack|
-      jack.action do |global_options, options, _args|
-        opts = options.merge(global_options)
-        GoodData::Command::Project.jack_in(opts)
       end
     end
   end

--- a/lib/gooddata/cli/hooks.rb
+++ b/lib/gooddata/cli/hooks.rb
@@ -49,7 +49,6 @@ GoodData::CLI.module_eval do
   on_error do |_exception|
     # Error logic here
     # return false to skip default error handling
-    # binding.pry
     # pp exception.backtrace
     # pp exception
     true

--- a/lib/gooddata/commands/project.rb
+++ b/lib/gooddata/commands/project.rb
@@ -103,36 +103,6 @@ module GoodData
           client.with_project(project_id, &:validate)
         end
 
-        def jack_in(options)
-          goodfile_path = GoodData::Helpers.find_goodfile(Pathname('.'))
-
-          spin_session = proc do |goodfile|
-            project_id = options[:project_id] || goodfile[:project_id]
-
-            begin
-              require 'gooddata'
-              client = GoodData.connect(options)
-              project = client.projects(project_id) if project_id
-              puts "Use 'exit' to quit the live session. Use 'q' to jump out of displaying a large output."
-              binding.pry(:quiet => true, # rubocop:disable Lint/Debugger
-                          :prompt => [proc do |_target_self, _nest_level, _pry|
-                            'project_live_session: '
-                          end])
-            rescue GoodData::ProjectNotFound
-              puts "Project with id \"#{project_id}\" could not be found. Make sure that the id you provided is correct."
-            end
-          end
-
-          if goodfile_path
-            goodfile = MultiJson.load(File.read(goodfile_path), :symbolize_keys => true)
-            FileUtils.cd(goodfile_path.dirname) do
-              spin_session.call(goodfile)
-            end
-          else
-            spin_session.call({}, nil)
-          end
-        end
-
         # Lists roles in a project
         #
         # @param project_id [String | GoodData::Project] Project id or project instance to list the users in

--- a/lib/gooddata/models/process.rb
+++ b/lib/gooddata/models/process.rb
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-require 'pry'
 require 'zip'
 require 'uri'
 

--- a/spec/bricks/bricks_spec.rb
+++ b/spec/bricks/bricks_spec.rb
@@ -7,7 +7,6 @@
 require 'gooddata/bricks/brick'
 require 'gooddata/bricks/bricks'
 require 'gooddata/bricks/middleware/base_middleware'
-require 'pry'
 
 describe GoodData::Bricks do
   it "Has GoodData::Bricks::Brick class" do

--- a/spec/logging_in_logging_out_spec.rb
+++ b/spec/logging_in_logging_out_spec.rb
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 require 'gooddata'
-require 'pry'
 
 describe GoodData::Rest::Connection, :constraint => 'slow' do
 

--- a/spec/unit/models/blueprint/schema_builder_spec.rb
+++ b/spec/unit/models/blueprint/schema_builder_spec.rb
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-require 'pry'
 require 'gooddata/models/model'
 
 describe GoodData::Model::SchemaBuilder do

--- a/spec/unit/models/model_spec.rb
+++ b/spec/unit/models/model_spec.rb
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-require 'pry'
 require 'gooddata/models/model'
 
 describe GoodData::Model do
@@ -47,7 +46,7 @@ describe GoodData::Model do
   end
 
   it "should be possible to merge Schema blueprints" do
-    
+
     first_dataset = @base_blueprint.find_dataset("dataset.devs").to_hash
     additional_blueprint = @additional_blueprint.find_dataset("dataset.devs").to_hash
     stuff = GoodData::Model.merge_dataset_columns(first_dataset, additional_blueprint)
@@ -61,7 +60,7 @@ describe GoodData::Model do
     first_dataset = @base_blueprint.find_dataset("dataset.commits").to_hash
     additional_blueprint = @blueprint_with_duplicate.find_dataset("dataset.commits").to_hash
     stuff = GoodData::Model.merge_dataset_columns(first_dataset, additional_blueprint)
-    
+
     expect(GoodData::Model::ProjectBlueprint.new(stuff)).to be_valid
 
     expect(stuff[:columns].count).to eq 6


### PR DESCRIPTION
Since pry is a development tool, it is inadvisable to require it as a production dependency.

Although the jack_in functionality is useful, you can achieve the same thing with existing tools (Rails console for example).

Finally, I would propose that it is better to defer the decision of requiring Pry or not to the project that uses the gem.

Thoughts? And thanks again Tomas for your help this week.

cc @AnnaMhairi @diclophis 