### PR TITLE
Updated the manifest to allow for reference_label specification

### DIFF
--- a/lib/gooddata/models/blueprint/anchor_field.rb
+++ b/lib/gooddata/models/blueprint/anchor_field.rb
@@ -55,9 +55,10 @@ module GoodData
       #
       # @return [Array<Hash>] Returns list of errors as hashes
       def validate
-        validate_presence_of(:id).map do |e|
+        errors = super
+        errors.concat(validate_presence_of(:id).map do |e|
           { type: :error, message: "Field \"#{e}\" is not defined or empty for anchor \"#{id}\"" }
-        end
+        end)
       end
     end
   end

--- a/lib/gooddata/models/blueprint/attribute_field.rb
+++ b/lib/gooddata/models/blueprint/attribute_field.rb
@@ -9,6 +9,15 @@ require_relative 'blueprint_field'
 module GoodData
   module Model
     class AttributeBlueprintField < BlueprintField
+      # Returns label that is considered referencing. It is either first one or the one marked
+      # with reference_label: true in blueprint
+      #
+      # @return [Array<GoodData::Model::LabelBlueprintField>] Returns list of labels
+      def reference_label
+        reference_label = labels.find { |label| label.respond_to?(:reference_label) && label.reference_label == true }
+        reference_label || labels.first
+      end
+
       # Returns list of labels on the attribute. There has to be always at least one attribute
       #
       # @return [Array] returns list of the errors represented by hash structures
@@ -20,9 +29,16 @@ module GoodData
       #
       # @return [Array] returns list of the errors represented by hash structures
       def validate
-        validate_presence_of(:id).map do |e|
+        errors = validate_presence_of(:id).map do |e|
           { type: :error, message: "Field \"#{e}\" is not defined or empty for attribute \"#{id}\"" }
         end
+        if labels.select(&:reference_label?).count > 1
+          errors << {
+            type: :error,
+            message: "Anchor \"#{id}\" can have only one label with reference_label field set to true"
+          }
+        end
+        errors
       end
     end
   end

--- a/lib/gooddata/models/blueprint/dataset_blueprint.rb
+++ b/lib/gooddata/models/blueprint/dataset_blueprint.rb
@@ -144,6 +144,11 @@ module GoodData
         find_columns_by_type(dataset, :label)
       end
 
+      def self.reference_label_for_attribtue(dataset, attribute)
+        labels = labels_for_attribute(dataset, attribute)
+        labels.find { |label| label[:reference_label] == true } || labels.first
+      end
+
       # Returns labels for a particular attribute
       #
       # @param dataset [Hash] Dataset blueprint

--- a/lib/gooddata/models/blueprint/label_field.rb
+++ b/lib/gooddata/models/blueprint/label_field.rb
@@ -16,6 +16,10 @@ module GoodData
         dataset_blueprint.attribute_for_label(self)
       end
 
+      def reference_label?
+        data[:reference_label] == true || self == attribute.reference_label
+      end
+
       # Returns gd_data_type
       #
       # @return [String] returns gd_data_type of the label

--- a/lib/gooddata/models/blueprint/to_manifest.rb
+++ b/lib/gooddata/models/blueprint/to_manifest.rb
@@ -125,7 +125,11 @@ module GoodData
         labels = DatasetBlueprint.labels_for_attribute(dataset, a)
 
         label = {}.tap do |l|
-          l['referenceKey'] = 1 if labels.first == label
+          if labels.any? { |lab| lab.key?(:reference_label) } && label[:reference_label] == true
+            l['referenceKey'] = 1
+          elsif labels.all? { |lab| !lab.key?(:reference_label) } && labels.first == label
+            l['referenceKey'] = 1
+          end
           l['populates'] = [label[:id]]
           l['mode'] = mode
           l['columnName'] = label[:column_name] || label[:id]
@@ -168,7 +172,7 @@ module GoodData
       def self.reference_to_manifest(project, _dataset, reference, mode)
         referenced_dataset = ProjectBlueprint.find_dataset(project, reference[:dataset])
         anchor = DatasetBlueprint.anchor(referenced_dataset)
-        label = DatasetBlueprint.labels_for_attribute(referenced_dataset, anchor).first
+        label = DatasetBlueprint.reference_label_for_attribtue(referenced_dataset, anchor)
         [{
           'populates' => [label[:id]],
           'mode' => mode,

--- a/spec/unit/models/to_manifest_spec.rb
+++ b/spec/unit/models/to_manifest_spec.rb
@@ -60,4 +60,71 @@ describe GoodData::Model::ToManifest do
     end
     expect(blueprint.to_manifest.first['dataSetSLIManifest']['parts'].count).to eq 4
   end
+
+  it 'blueprint can be specified to have a reference key. The manifest respects it. If not it takes the first key.' do
+    blueprint = GoodData::Model::ProjectBlueprint.build("my_bp") do |p|
+      p.add_date_dimension("committed_on")
+
+      p.add_dataset("repos") do |d|
+        d.add_anchor("repo_id")
+        d.add_label("repo_label_1", reference: "repo_id")
+        d.add_label("repo_label_2", reference: "repo_id")
+        d.add_attribute("name")
+        d.add_label("name_label", reference: "name")
+
+        d.add_date('opportunity_comitted', dataset: 'committed_on', format: 'yyyy/MM/dd')
+        d.add_column(type: :date_fact, id: 'dt.date_fact')
+      end
+    end
+    expect(blueprint.to_manifest.first['dataSetSLIManifest']['parts']).to include({"referenceKey"=>1, "populates"=>["repo_label_1"], "mode"=>"FULL", "columnName"=>"repo_label_1"})
+
+    blueprint = GoodData::Model::ProjectBlueprint.build("my_bp") do |p|
+      p.add_date_dimension("committed_on")
+
+      p.add_dataset("repos") do |d|
+        d.add_anchor("repo_id")
+        d.add_label("repo_label_1", reference: "repo_id")
+        d.add_label("repo_label_2", reference: "repo_id", reference_label: true)
+        d.add_attribute("name")
+        d.add_label("name_label", reference: "name")
+
+        d.add_date('opportunity_comitted', dataset: 'committed_on', format: 'yyyy/MM/dd')
+      end
+
+      p.add_dataset("commits") do |d|
+        d.add_anchor("commits_id")
+        d.add_fact('lines')
+        d.add_reference('repos')
+      end
+    end
+
+    expect(blueprint.to_manifest.first['dataSetSLIManifest']['parts']).to include({"referenceKey"=>1, "populates"=>["repo_label_2"], "mode"=>"FULL", "columnName"=>"repo_label_2"})
+    expect(blueprint.to_manifest[1]['dataSetSLIManifest']['parts']).to include({"populates"=>["repo_label_2"], "mode"=>"FULL", "columnName"=>"repos", "referenceKey"=>1})
+  end
+
+  it 'blueprint cannot have more than one reference key.' do
+    blueprint = GoodData::Model::ProjectBlueprint.build("my_bp") do |p|
+      p.add_date_dimension("committed_on")
+
+      p.add_dataset("repos") do |d|
+        d.add_anchor("repo_id")
+        d.add_label("repo_label_1", reference: "repo_id", reference_label: true)
+        d.add_label("repo_label_2", reference: "repo_id", reference_label: true)
+        d.add_attribute("name")
+        d.add_label("name_label", reference: "name")
+
+        d.add_date('opportunity_comitted', dataset: 'committed_on', format: 'yyyy/MM/dd')
+        d.add_column(type: :date_fact, id: 'dt.date_fact')
+      end
+    end
+    
+    expect(blueprint.valid?).to be false
+    expect(blueprint.validate).to eq [
+      {
+        type: :error,
+        message: "Anchor \"repo_id\" can have only one label with reference_label field set to true"
+      }
+    ]
+  end
+  
 end


### PR DESCRIPTION
New rubocop seems to be release again so there are some violations. Did not fix it now so Mavenlink can investigate and merge the patch to their branch.