### PR TITLE
TRIVIAL: Replace deprecated usage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,9 +75,9 @@ RSpec.configure do |config|
   end
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   SimpleCov::Formatter::HTMLFormatter
-]
+)
 
 SimpleCov.start do
   add_filter 'spec/'


### PR DESCRIPTION
Warning:
```/github/gooddata-ruby/spec/spec_helper.rb:78:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.```