### PR TITLE
BUGFIX: Always use nokogiri version 1.6.8.1 in Ruby 2.0.0

### DIFF
--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard-rspec', '~> 0.1'
   s.add_development_dependency 'ZenTest', '~> 4.10', '>= 4.11.0'
 
+  s.add_dependency 'nokogiri', '~> 1.6.8'
   s.add_dependency 'aws-sdk-v1', '~> 1.45'
   s.add_dependency 'docile', '~> 1.1', '>= 1.1.5'
   s.add_dependency 'erubis', '~> 2.7', '>= 2.7.0'


### PR DESCRIPTION
(cherry picked from commit 8195566cfa81e9e335db5b2985f600c18110ef4c)