### PR TITLE
Invitation bug

### DIFF
--- a/lib/gooddata/models/project.rb
+++ b/lib/gooddata/models/project.rb
@@ -833,7 +833,7 @@ module GoodData
       puts "Inviting #{email}, role: #{role}"
 
       role_url = nil
-      if role.index('/gdc/').nonzero?
+      if role.index('/gdc/').nil?
         tmp = get_role(role)
         role_url = tmp.uri if tmp
       else


### PR DESCRIPTION
You call nonzero methon on nil class. Example '4'.index('/gdc/') is nil.

Please fix it. Thank you