### PR TITLE
import_users : Enable adding user logins similar to whitelisted to projects

### DIFF
--- a/lib/gooddata/models/project.rb
+++ b/lib/gooddata/models/project.rb
@@ -1426,12 +1426,25 @@ module GoodData
       return [new_users, users_list] unless whitelist
 
       new_whitelist_proc = proc do |user|
-        whitelist.any? { |wl| wl.is_a?(Regexp) ? user[:login] =~ wl : (user[:login] && user[:login].eql?(wl)) }
+        whitelist.any? do |wl| 
+          if wl.is_a?(Regexp) 
+              user[:login] =~ wl
+          else
+            user[:login] && user[:login].eql?(wl)
+          end
+        end
       end
 
       whitelist_proc = proc do |user|
-        whitelist.any? { |wl| wl.is_a?(Regexp) ? user.login =~ wl : (user.login && user.login.eql?(wl)) }
+        whitelist.any? do |wl| 
+          if wl.is_a?(Regexp) 
+              user.login =~ wl
+          else
+            user.login && user.login.eql?(wl)
+          end
+        end
       end
+      
 
       if mode == :include
         [new_users.select(&new_whitelist_proc), users_list.select(&whitelist_proc)]

--- a/lib/gooddata/models/project.rb
+++ b/lib/gooddata/models/project.rb
@@ -1426,11 +1426,11 @@ module GoodData
       return [new_users, users_list] unless whitelist
 
       new_whitelist_proc = proc do |user|
-        whitelist.any? { |wl| wl.is_a?(Regexp) ? user[:login] =~ wl : (user[:login] && user[:login].include?(wl)) }
+        whitelist.any? { |wl| wl.is_a?(Regexp) ? user[:login] =~ wl : (user[:login] && user[:login].eql?(wl)) }
       end
 
       whitelist_proc = proc do |user|
-        whitelist.any? { |wl| wl.is_a?(Regexp) ? user.login =~ wl : (user.login && user.login.include?(wl)) }
+        whitelist.any? { |wl| wl.is_a?(Regexp) ? user.login =~ wl : (user.login && user.login.eql?(wl)) }
       end
 
       if mode == :include


### PR DESCRIPTION
Currently when the string of a requested new login to be added to the project includes the whitelisted login string, user will not be  added.
E.g: when calling:

`
project.import_users([{user: {login: 'simple_user@example.com'}, role: 'dashboardOnly'}], domain: 'example-domain', whitelists: ['user@example.com'])
`

the user 'simple_user@example.com' will not be added to the project