### PR TITLE
BUGFIX: TMA-393 LCM2 Provisioning and Rollout bricks does not set CLI…

### DIFF
--- a/lib/gooddata/lcm/actions/synchronize_etls_in_segment.rb
+++ b/lib/gooddata/lcm/actions/synchronize_etls_in_segment.rb
@@ -71,7 +71,7 @@ module GoodData
               pid = entry[:pid]
               to_project = client.projects(pid) || fail("Invalid 'to' project specified - '#{pid}'")
               to_project.schedules.each do |schedule|
-                schedule.update_params(params.additional_params || {})
+                schedule.update_params((params.additional_params || {}).merge(CLIENT_ID: entry[:client_id]))
                 schedule.update_hidden_params(params.additional_hidden_params || {})
                 schedule.save
               end


### PR DESCRIPTION
…ENT_ID param in client workspaces