### PR TITLE
BUGFIX: TMA-424 Rollout brick synchronize only new computed attribute without drilldrosspath

### DIFF
--- a/lib/gooddata/lcm/lcm2.rb
+++ b/lib/gooddata/lcm/lcm2.rb
@@ -118,12 +118,14 @@ module GoodData
         EnsureTechnicalUsersDomain,
         EnsureTechnicalUsersProject,
         SynchronizeLdm,
+        CollectComputedAttributeMetrics,
+        ImportObjectCollections,
+        SynchronizeComputedAttributes, # need to sync CA here to maintain the drill path after that
         # SynchronizeLabelTypes,
         SynchronizeAttributeDrillpath,
         ApplyCustomMaql,
         SynchronizeColorPalette,
         SynchronizeClients,
-        SynchronizeComputedAttributes,
         SynchronizeETLsInSegment
       ]
     }


### PR DESCRIPTION


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
- [ ] Build passing
