### PR TITLE
TMA-339: RubySDK middleware connects to wrong cluster when using SST …

### DIFF
--- a/lib/gooddata/bricks/middleware/gooddata_middleware.rb
+++ b/lib/gooddata/bricks/middleware/gooddata_middleware.rb
@@ -26,7 +26,7 @@ module GoodData
         GoodData.logger = logger
 
         # Connect Client
-        protocol = params['CLIENT_GDC_PROTOCOL'] || DEFAULT_PROTOCOL
+        protocol = params['CLIENT_GDC_PROTOCOL'] || params['GDC_PROTOCOL'] || DEFAULT_PROTOCOL
         hostname = params['CLIENT_GDC_HOSTNAME'] || params['GDC_HOSTNAME'] || DEFAULT_HOSTNAME
         server = "#{protocol}://#{hostname}"
         client = GoodDataMiddleware.connect(

--- a/lib/gooddata/bricks/middleware/gooddata_middleware.rb
+++ b/lib/gooddata/bricks/middleware/gooddata_middleware.rb
@@ -27,7 +27,7 @@ module GoodData
 
         # Connect Client
         protocol = params['CLIENT_GDC_PROTOCOL'] || DEFAULT_PROTOCOL
-        hostname = params['CLIENT_GDC_HOSTNAME'] || DEFAULT_HOSTNAME
+        hostname = params['CLIENT_GDC_HOSTNAME'] || params['GDC_HOSTNAME'] || DEFAULT_HOSTNAME
         server = "#{protocol}://#{hostname}"
         client = GoodDataMiddleware.connect(
           server,


### PR DESCRIPTION
…in bricks

Fixes tma-339

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
- [ ] Build passing
