### PR TITLE
Make LCM2.print_action_results more robust

### DIFF
--- a/lib/gooddata/lcm/lcm2.rb
+++ b/lib/gooddata/lcm/lcm2.rb
@@ -217,7 +217,7 @@ module GoodData
 
         table = Terminal::Table.new :title => title, :headings => headings do |t|
           rows.each_with_index do |row, index|
-            t << row
+            t << (row || [])
             t.add_separator if index < rows.length - 1
           end
         end


### PR DESCRIPTION
So that it doesn't explode when there's a nil.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
- [ ] Build passing
