### PR TITLE
Add parameter HTTP_LOGGING to LoggerMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix bug with transfering schedules without their state
 - Support segment-specific production tags (TMA-309)
 - Rewrite deprecated schedule parameter "GRAPH" (TMA-453)
+- Add parameter HTTP_LOGGING to LoggerMiddleware
 - Support integer type id in Domain#clients (TMA-450)
 
 ## 0.6.50

--- a/lib/gooddata/bricks/middleware/logger_middleware.rb
+++ b/lib/gooddata/bricks/middleware/logger_middleware.rb
@@ -22,6 +22,8 @@ module GoodData
           logger.info('Pipeline starts')
         end
         params['GDC_LOGGER'] = logger
+        GoodData.logging_http_on if params['HTTP_LOGGING'] && params['HTTP_LOGGING'].to_b
+
         returning(@app.call(params)) do |_result|
           logger.info('Pipeline ending')
         end

--- a/spec/unit/bricks/middleware/logger_middleware_spec.rb
+++ b/spec/unit/bricks/middleware/logger_middleware_spec.rb
@@ -12,4 +12,19 @@ describe GoodData::Bricks::LoggerMiddleware do
   it "Has GoodData::Bricks::LoggerMiddleware class" do
     GoodData::Bricks::LoggerMiddleware.should_not be(nil)
   end
+
+  context 'when HTTP_LOGGING parameter set to true' do
+    let(:params) { { 'HTTP_LOGGING' => 'true' } }
+    let(:app) { double(:app) }
+
+    before do
+      subject.app = app
+      allow(app).to receive(:call)
+    end
+
+    it 'turns http logging on' do
+      expect(GoodData).to receive(:logging_http_on)
+      subject.call(params)
+    end
+  end
 end


### PR DESCRIPTION
This will enable debugging of deployed bricks.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
- [ ] Build passing
