### PR TITLE
BUGFIX: TMA-500 Provisioning: undefined method '[]' for nil:NilClass …

### DIFF
--- a/lib/gooddata/lcm/lcm2.rb
+++ b/lib/gooddata/lcm/lcm2.rb
@@ -293,6 +293,9 @@ module GoodData
             break if fail_early
           end
 
+          # in case fail_early = false, we need to execute another action
+          next unless out
+
           # Handle output results and params
           res = out.is_a?(Array) ? out : out[:results]
           out_params = out.is_a?(Hash) ? out[:params] || {} : {}


### PR DESCRIPTION
…when fail_early=false and limit on token reached

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
- [ ] Build passing
