### PR TITLE
TMA-506: RubySDK: add option to report.execute to set timestamp for 'THIS'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # GoodData Ruby SDK Changelog
 
 ## 0.6.54
+- TMA-506 - Add option :time to report.execute to force platform simulate the result of report at that time
 
 ## 0.6.53
 - TMA-522 - Rollout: Incorrect CLIENT_ID assigned to client schedule

--- a/lib/gooddata/models/metadata/report.rb
+++ b/lib/gooddata/models/metadata/report.rb
@@ -144,10 +144,16 @@ module GoodData
 
     # Computes the report and returns the result. If it is not computable returns nil.
     #
+    # @option options [Time] :time Force the platform to simutale the result at this time
     # @return [GoodData::DataResult] Returns the result
     def execute(options = {})
+      time = options[:time]
+
+      report_req = { 'report' => uri }
+      report_req['timestamp'] = time.strftime('%s') if time
+
       fail 'You have to save the report before executing. If you do not want to do that please use GoodData::ReportDefinition' unless saved?
-      result = client.post '/gdc/xtab2/executor3', 'report_req' => { 'report' => uri }
+      result = client.post '/gdc/xtab2/executor3', 'report_req' => report_req
       GoodData::Report.data_result(result, options.merge(client: client))
     end
 

--- a/spec/integration/date_dim_switch_spec.rb
+++ b/spec/integration/date_dim_switch_spec.rb
@@ -40,6 +40,19 @@ describe "Swapping a date dimension and exchanging all attributes/elements", :co
     @client.disconnect
   end
 
+  it 'should not get error when execute report with timestamp' do
+    metric = @project.attributes('created_on.date').create_metric(title: 'test_metric')
+    metric.save
+
+    report = @project.create_report(
+      left: metric,
+      top: ['created_on.quarter'],
+      filters: [['created_on.year', 2015, 2016]],
+      title: 'test_report'
+    )
+    report.execute(time: Time.now)
+  end
+
   it "should swap the dimension, exchange all stuffs and not break anything" do
     # WE have 2 date dims
     expect(@blueprint.date_dimensions.map(&:id)).to eq %w(created_on created_on_2)


### PR DESCRIPTION


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
- [ ] Build passing
