### PR TITLE
Make activesupport a development dependency

### DIFF
--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard-rspec', '~> 0.1'
   s.add_development_dependency 'ZenTest', '~> 4.11'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'activesupport', '~> 4.2.9'
 
   s.add_dependency 'aws-sdk', '~> 2.9', '>= 2.9.42'
   s.add_dependency 'docile', '~> 1.1'
@@ -60,5 +61,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'terminal-table', '~> 1.7'
   s.add_dependency 'thread_safe'
   s.add_dependency 'backports'
-  s.add_dependency 'activesupport', '~> 4.2.9'
 end


### PR DESCRIPTION
In order to prevent issues like this:
https://github.com/gooddata/gooddata-ruby/issues/503