### PR TITLE
TMA-819: requests to the profile/email@addr API always use downcase

### DIFF
--- a/lib/gooddata/models/user_filters/user_filter_builder.rb
+++ b/lib/gooddata/models/user_filters/user_filter_builder.rb
@@ -271,10 +271,10 @@ module GoodData
       attrs_cache = create_attrs_cache(filters, options)
       create_filter_proc = proc do |login, f|
         expression, errors = create_expression(f, labels_cache, lookups_cache, attrs_cache, options)
+        safe_login = login.downcase
         profiles_uri = if options[:type] == :muf
                          project_user = project_users.find { |u| u.login == login }
-
-                         project_user.nil? ? ('/gdc/account/profile/' + login) : project_user.profile_url
+                         project_user.nil? ? ('/gdc/account/profile/' + safe_login) : project_user.profile_url
                        elsif options[:type] == :variable
                          (users_cache[login] && users_cache[login].uri)
                        else


### PR DESCRIPTION
This reverts commit 66b4b7ac5dc943e11c0e179490d27d6699603386, which was a revert of the original implementation.