### PR TITLE
Use Travis for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: ruby
 cache: bundler
-
-rvm:
- - 2.2
- - jruby-9.1.7
-
-script:
-  - bundle exec rake test:unit
+stages:
+  - unit
+  - name: integration
+    if: type = api
+jobs:
+  include:
+    - stage: unit
+      script: bundle exec rake test:unit
+      rvm:
+        - 2.2
+        - jruby-9.1.7
+    - stage: integration
+      script: bundle exec rake test:integration
+      rvm: jruby-9.1.7


### PR DESCRIPTION
Pull requests trigger only unit tests. Trigger the build manually from Travis to run also integration tests. GD_SPEC_PASSWORD environment variable must be set in you Travis to run integration tests.