### PR TITLE
TMA-929: Fix passing user id to docker container

### DIFF
--- a/ci.rake
+++ b/ci.rake
@@ -33,14 +33,14 @@ end
 namespace :test do
   namespace :unit do
     task :docker do
-      system('docker-compose run -u 1002:1002 -e HOME=/var/lib/jenkins-slave gooddata-ruby bundle exec rake test:unit') ||
+      system('docker-compose run -u $(id -u):$(id -g) -e HOME=/var/lib/jenkins-slave gooddata-ruby bundle exec rake test:unit') ||
         fail('Test execution failed!')
     end
   end
 
   namespace :integration do
     task :docker do
-      system('docker-compose run -u 1002:1002 -e HOME=/var/lib/jenkins-slave gooddata-jruby bundle exec rake test:integration') ||
+      system('docker-compose run -u $(id -u):$(id -g) -e HOME=/var/lib/jenkins-slave gooddata-jruby bundle exec rake test:integration') ||
         fail('Test execution failed!')
     end
   end


### PR DESCRIPTION
Uses true user and group id instead of a hard-coded value.
Integration tests would fail in new Jenkins because of it.