### PR TITLE
Remove monkey patchs from Hash

### DIFF
--- a/lib/gooddata/extensions/hash.rb
+++ b/lib/gooddata/extensions/hash.rb
@@ -5,38 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 class Hash
-  # Return a hash that includes everything but the given keys. This is useful for
-  # limiting a set of parameters to everything but a few known toggles:
-  #
-  #   @person.update_attributes(params[:person].except(:admin))
-  #
-  # If the receiver responds to +convert_key+, the method is called on each of the
-  # arguments. This allows +except+ to play nice with hashes with indifferent access
-  # for instance:
-  #
-  #   {:a => 1}.with_indifferent_access.except(:a)  # => {}
-  #   {:a => 1}.with_indifferent_access.except("a") # => {}
-  #
-  def except(*keys)
-    dup.except!(*keys)
-  end
-
-  # Replaces the hash without the given keys.
-  def except!(*keys)
-    keys.each { |key| delete(key) }
-    self
-  end
-
-  def slice(*keys)
-    keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
-    keys.each_with_object(self.class.new) { |k, hash| hash[k] = self[k] if key?(k) }
-  end
-
-  def compact
-    select { |_, value| !value.nil? }
-  end
-
-  def deep_merge(hash)
+  def custom_deep_merge(hash)
     hash = hash.to_hash
     merge(hash) do |_key, old_val, new_val|
       if old_val.is_a?(Hash) && new_val.is_a?(Hash)

--- a/lib/gooddata/helpers/global_helpers_params.rb
+++ b/lib/gooddata/helpers/global_helpers_params.rb
@@ -100,7 +100,7 @@ module GoodData
 
         params.delete(key)
         params.delete(hidden_key)
-        params = params.deep_merge(parsed_data_params).deep_merge(parsed_hidden_data_params)
+        params = params.custom_deep_merge(parsed_data_params).custom_deep_merge(parsed_hidden_data_params)
 
         if options[:convert_pipe_delimited_params]
           convert_pipe_delimited_params = lambda do |args|
@@ -119,7 +119,7 @@ module GoodData
             end
 
             lines.reduce({}) do |a, e|
-              a.deep_merge(e)
+              a.custom_deep_merge(e)
             end
           end
 
@@ -127,7 +127,7 @@ module GoodData
           params.delete_if do |k, _|
             k.include?('|')
           end
-          params = params.deep_merge(pipe_delimited_params)
+          params = params.custom_deep_merge(pipe_delimited_params)
         end
 
         params


### PR DESCRIPTION
Just remove monkey-patchs that already exists in `ActiveSupport` gem.