### PR TITLE
FEATURE: TMA-1030 Raise jruby version used in K8s docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM harbor.intgdc.com/tools/gdc-java-8-jre:b057b53
 
-MAINTAINER lcm <lcm@gooddata.com>
+MAINTAINER LCM <lcm@gooddata.com>
 
 LABEL image_name="GDC LCM Bricks"
 LABEL maintainer="LCM <lcm@gooddata.com>"
@@ -13,7 +13,7 @@ RUN yum install -y curl which \
     && rm -rf /var/cache/yum
 
 RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-RUN curl -sSL https://get.rvm.io | bash -s stable --ruby=jruby-9.1.5.0
+RUN curl -sSL https://get.rvm.io | bash -s stable --ruby=jruby-9.1.14
 
 # Switch to directory with sources
 WORKDIR /src


### PR DESCRIPTION
Version 9.1.14 is free of memory leaks and mainly used for LCM bricks.