### PR TITLE
BUGFIX: SETI-2444 fix docker run on jenkins slaves

### DIFF
--- a/Dockerfile.ruby
+++ b/Dockerfile.ruby
@@ -2,7 +2,7 @@ FROM ruby:2.3-alpine
 
 MAINTAINER Tomas Korcak <korczis@gmail.com>
 
-RUN apk add --no-cache curl make gcc git g++ python linux-headers binutils-gold gnupg libstdc++ openssl cmake
+RUN apk add --no-cache curl make gcc git g++ python linux-headers binutils-gold gnupg libstdc++ openssl cmake curl-dev
 
 RUN ln -s /usr/bin/make /usr/bin/gmake
 

--- a/ci.rake
+++ b/ci.rake
@@ -7,11 +7,11 @@ namespace :docker do
   desc 'Bundles gems using cache'
   namespace :bundle do
     task :ruby do
-      system('docker-compose run gooddata-ruby bundle')
+      system('docker-compose run --rm gooddata-ruby bundle')
     end
 
     task :jruby do
-      system('docker-compose run gooddata-jruby bundle')
+      system('docker-compose run --rm gooddata-jruby bundle')
     end
   end
 end


### PR DESCRIPTION
`rake -f ci.rake docker:bundle:ruby` was failing on some jenkins slaves. Problem wasn't related to our service, but to missing dependencies in the built image.

Run of bundler inside the image failed on rugged gem, which couldn't build native part because of missing curl-dev package:

```
Fetching rugged 0.27.5
Installing rugged 0.27.5 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /bundle/gems/rugged-0.27.5/ext/rugged
/usr/local/bin/ruby -r ./siteconf20181024-1-1mt102h.rb extconf.rb
checking for gmake... yes
checking for cmake... yes
checking for pkg-config... yes
 -- cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/usr/local/bin/$(RUBY_BASE_NAME)
        --with-sha1dc
        --without-sha1dc
        --use-system-libraries
extconf.rb:21:in `sys': ERROR: 'cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo  ' failed
(RuntimeError)
        from extconf.rb:83:in `block (2 levels) in <main>'
        from extconf.rb:80:in `chdir'
        from extconf.rb:80:in `block in <main>'
        from extconf.rb:77:in `chdir'
        from extconf.rb:77:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /bundle/extensions/x86_64-linux/2.3.0/rugged-0.27.5/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /bundle/gems/rugged-0.27.5 for inspection.
Results logged to /bundle/extensions/x86_64-linux/2.3.0/rugged-0.27.5/gem_make.out

An error occurred while installing rugged (0.27.5), and Bundler cannot continue.
Make sure that `gem install rugged -v '0.27.5' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  pronto-flay was resolved to 0.9.0, which depends on
    pronto was resolved to 0.9.5, which depends on
      rugged
```

Let's fix it.