### PR TITLE
BUGFIX: TMA-1218 Anonymise hidden parameters only in LCM bricks running in K8s

### DIFF
--- a/bin/run_brick.rb
+++ b/bin/run_brick.rb
@@ -5,6 +5,7 @@ require_relative '../lib/gooddata'
 
 DEFAULT_BRICK = 'hello_world_brick'
 BRICK_PARAM_PREFIX = 'BRICK_PARAM_'
+HIDDEN_BRICK_PARAMS_PREFIX = 'HIDDEN_BRICK_PARAM_'
 
 brick_type = !ARGV.empty? ? ARGV[0] : DEFAULT_BRICK
 
@@ -13,17 +14,22 @@ log = RemoteSyslogLogger.new(syslog_node, 514, :program => "ruby_#{brick_type}",
 
 log.info "action=#{brick_type}_execution status=init"
 
+def get_brick_params(prefix)
+  ENV.select { |k,| k.to_s.match(/^#{prefix}.*/) }.map { |k, v| [k.slice(prefix.length..-1), v] }.to_h
+end
+
 begin
   brick_pipeline = GoodData::Bricks::Pipeline.send("#{brick_type}_pipeline")
-  params = ENV.select { |k,| k.to_s.match(/^#{BRICK_PARAM_PREFIX}.*/) }.map { |k, v| [k.slice(BRICK_PARAM_PREFIX.length..-1), v] }.to_h
-  params['values_to_mask'] = params.values
+  normal_params = get_brick_params(BRICK_PARAM_PREFIX)
+  hidden_params = get_brick_params(HIDDEN_BRICK_PARAMS_PREFIX)
+  params = normal_params.merge(hidden_params)
+
+  params['values_to_mask'] = hidden_params.values
   commit_hash = ENV['GOODDATA_RUBY_COMMIT'] || ''
-  execution_id = ENV['EXECUTION_ID']
+  execution_id = ENV['GDC_EXECUTION_ID']
   params['gooddata_ruby_commit'] = commit_hash
-  params['log_directory'] = ENV['LOG_DIRECTORY'] || '/tmp/'
-  params['project_id'] = ENV['PROJECT_ID']
-  params['process_id'] = ENV['PROCESS_ID']
-  params['execution_id'] = execution_id
+  params['GDC_LOG_DIRECTORY'] = ENV['GDC_LOG_DIRECTORY'] || '/tmp/'
+  params['GDC_EXECUTION_ID'] = execution_id
   log.info "action=#{brick_type}_execution status=start commit_hash=#{commit_hash} execution_id=#{execution_id}"
   @brick_result = brick_pipeline.call(params)
   log.info "action=#{brick_type}_execution status=finished"

--- a/lib/gooddata/bricks/middleware/logger_middleware.rb
+++ b/lib/gooddata/bricks/middleware/logger_middleware.rb
@@ -28,9 +28,9 @@ module GoodData
         params = params.to_hash
         if params['GDC_LOGGING_OFF']
           logger = NilLogger.new
-        elsif params['log_directory'] && params['execution_id']
-          log_directory = params['log_directory']
-          execution_id = params['execution_id']
+        elsif params['GDC_LOG_DIRECTORY'] && params['GDC_EXECUTION_ID']
+          log_directory = params['GDC_LOG_DIRECTORY']
+          execution_id = params['GDC_EXECUTION_ID']
           FileUtils.mkpath log_directory
           logger = Logger.new("#{log_directory}/#{execution_id}.log")
           logger.level = params['GDC_LOG_LEVEL'] || 'info'

--- a/lib/gooddata/lcm/lcm2.rb
+++ b/lib/gooddata/lcm/lcm2.rb
@@ -309,7 +309,7 @@ module GoodData
         errors = []
         results = []
         actions.each do |action|
-          GoodData.logger.info
+          GoodData.logger.info("\n")
           # Invoke action
           begin
             out = run_action action, params

--- a/spec/unit/bricks/middleware/logger_middleware_spec.rb
+++ b/spec/unit/bricks/middleware/logger_middleware_spec.rb
@@ -69,7 +69,7 @@ describe GoodData::Bricks::LoggerMiddleware do
     tmp_dir = Dir.mktmpdir
     log_dir = tmp_dir + '/logs'
     execution_id = 'execid'
-    let(:params) { { 'execution_id' => execution_id, 'log_directory' => log_dir } }
+    let(:params) { { 'GDC_EXECUTION_ID' => execution_id, 'GDC_LOG_DIRECTORY' => log_dir } }
 
     it 'set MSF compatible file logger' do
       subject.call(params)


### PR DESCRIPTION
Also remove duplicate parameters 'process_id' and 'project_id' and rename
'execution_id' parameter to 'GDC_EXECUTION_ID' to be consistent with other
GDC parameters.