### PR TITLE
Encrypt notification recipient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -190,6 +190,6 @@ jobs:
 notifications:
   email:
     recipients:
-      - lcm@gooddata.com
+      secure: AMTssALc5Qt4ApAoI7gCmqP3d7AL0dGyZ+DsxYYlas2T0tjXdOH97XlY2jRzFSxZU1P3JKJkjHLmxu0m908Q28SQVcdBlK29Ofyl2pwGnniExY4wdQJLmqNW9eKa2dmSMUsntR6DryNThKVn9mqUACdXgpT8X2CnQl/DWMGpo80=
     on_success: always
     on_failure: always


### PR DESCRIPTION
mainly so that we're not spammed by forks