### PR TITLE
II-294: Update base image - CentOS 7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.intgdc.com/tools/gdc-java-8-jre:b057b53
+FROM harbor.intgdc.com/tools/gdc-java-8-jre:92b15b7
 
 ARG GIT_COMMIT=unspecified
 ARG BRICKS_VERSION=unspecified
@@ -6,7 +6,7 @@ ARG BRICKS_VERSION=unspecified
 LABEL image_name="GDC LCM Bricks"
 LABEL maintainer="LCM <lcm@gooddata.com>"
 LABEL git_repository_url="https://github.com/gooddata/gooddata-ruby/"
-LABEL parent_image="harbor.intgdc.com/tools/gdc-java-8-jre:b057b53"
+LABEL parent_image="harbor.intgdc.com/tools/gdc-java-8-jre:92b15b7"
 LABEL git_commit=$GIT_COMMIT
 LABEL bricks_version=$BRICKS_VERSION
 


### PR DESCRIPTION
Source commits:
* gooddata/gdc-docker-images@956803d: Automated base image update (gdc-docker-images, 27f4627)

Link: gooddata/gdc-docker-images#38

Source commits:
* 3f3203dd0a9a8e32f7a84cbee9af15fd122861c0: II-294: Update rspec test for base image to check version
* gooddata/gdc-docker-images@7cf451f: TRIVIAL: Drop build of adoptopenjdk 10

Not used, newer version is present.
* gooddata/gdc-docker-images@61c0df9: II-294: Update python package to 7.6 version
* gooddata/gdc-docker-images@a747d9f: II-294: Update java packages to 7.6 versions

Note:
* PR wasn't created automatically because pipeline logic is using the config file which is not yet used inside this repository (see https://github.com/gooddata/gooddata-ruby/pull/1345)