### PR TITLE
BUGFIX: TMA-1230 Return inner logger class in MaskLoggerDecorator

### DIFF
--- a/lib/gooddata/bricks/middleware/mask_logger_decorator.rb
+++ b/lib/gooddata/bricks/middleware/mask_logger_decorator.rb
@@ -21,6 +21,12 @@ module GoodData
         end
       end
 
+      # Decorator pretends being inner logger itselfs.
+      # @return inner logger class
+      def class
+        @logger.class
+      end
+
       private
 
       # Masks given message.

--- a/spec/unit/bricks/middleware/mask_logger_decorator_spec.rb
+++ b/spec/unit/bricks/middleware/mask_logger_decorator_spec.rb
@@ -33,5 +33,9 @@ describe GoodData::Bricks::MaskLoggerDecorator do
         subject.send(level, nil)
       end
     end
+
+    it "should pretend being inner logger" do
+      expect(subject.class).to eq(logger.class)
+    end
   end
 end


### PR DESCRIPTION
MaskLoggerDecorator pretends being inner logger which is useful
during brick parameter check.