### PR TITLE
TMA-1054: Rename monitoring rules definition

### DIFF
--- a/k8s/charts/lcm-bricks/Chart.yaml
+++ b/k8s/charts/lcm-bricks/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: lcm-bricks
 description: LCM Bricks
-version: 1.0.1
+version: 1.0.2

--- a/k8s/charts/lcm-bricks/templates/prometheus/alertingRules.yaml
+++ b/k8s/charts/lcm-bricks/templates/prometheus/alertingRules.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: lcm-bricks-service-monitoring-rules
+  name: lcm-bricks-monitoring-rules
   namespace: monitoring
   labels:
     app: lcm-bricks
@@ -10,9 +10,9 @@ metadata:
     chart: lcm-bricks
     release: {{ .Release.Name }}
 data:
-  lcm-bricks-service-monitoring-rules.yaml: |+
+  lcm-bricks-monitoring-rules.yaml: |+
     groups:
-    - name: lcm-bricks-service-monitoring-rules
+    - name: lcm-bricks-monitoring-rules
       rules:
       - record: "container_pod:lcm_pod_container_status_restarts:increase10m"
         expr: increase(kube_pod_container_status_restarts_total{namespace='{{ .Release.Namespace }}'}[10m])


### PR DESCRIPTION
I guess the "service" was there due to the copy paste from "grammar-service"