### PR TITLE
FEATURE: II-206 Use II config file

### DIFF
--- a/.gdc-ii-config.yaml
+++ b/.gdc-ii-config.yaml
@@ -1,3 +1,10 @@
+microservices:
+  lcm-bricks:
+    docker:
+      dockerfile: './Dockerfile'
+      argumentsFromFiles:
+        BRICKS_VERSION: 'VERSION'
+
 integratedTests:
   - env: bash
     path: .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,17 +5,4 @@
 @Library('pipelines-shared-libs')
 import com.gooddata.pipeline.Pipeline
 
-def config = [
-        'microservices': [
-                'lcm-bricks': [
-                        'docker': [
-                                'dockerfile': './Dockerfile',
-                                'arguments': [
-                                        'BRICKS_VERSION': { readFile('./VERSION').trim() }
-                                ]
-                        ]
-                ]
-        ]
-]
-
-Pipeline.get(this, config).run()
+Pipeline.resolve(this).run()


### PR DESCRIPTION
Loading closures has been deprecated for II pipelines. The necessary functionality for loading file content can now be specified in the configuration file.

Implements II-206, builds on II-328.