### PR TITLE
Fix pronto branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ jobs:
     stage: before-merge
     script: |
       git remote add upstream https://github.com/gooddata/gooddata-ruby.git
-      git fetch upstream master
-      bundle exec pronto run -c upstream/master --exit-code
+      git fetch upstream develop
+      bundle exec pronto run -c upstream/develop --exit-code
 
   - name: unit tests
     stage: before-merge


### PR DESCRIPTION
Since we started to use the develop branch,
Pronto needs to be run against it.