### PR TITLE
BUGFIX: TMA-1370 gooddata-ruby-integration-tests should be unstable in case tests are failed

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -3,3 +3,4 @@
 --require spec_helper
 --format RspecJunitFormatter
 --out junit.xml
+--failure-exit-code=0


### PR DESCRIPTION
The job should be fail only in case it cannot build, cannot run tests.

In case there are failed tests, it should return unstable because testwatch only watch unstable job then report JIRA ticket for fail tests.

https://jira.intgdc.com/browse/TMA-1370