### PR TITLE
Fix adding server response to error message

### DIFF
--- a/lib/gooddata/rest/connection.rb
+++ b/lib/gooddata/rest/connection.rb
@@ -471,9 +471,11 @@ module GoodData
           return exception unless exception.response
 
           response = JSON.parse(exception.response.body, symbolize_names: true)
-          return exception unless exception.message && response[:error] && response[:error][:message] && response[:error][:requestId]
+          return exception unless exception.message && response[:error] && response[:error][:message]
 
-          exception.message = exception.message + ': ' + response[:error][:message] % response[:error][:parameters] + ' request_id: ' + response[:error][:requestId]
+          request_id = exception.response.headers[:x_gdc_request] || 'unknown'
+
+          exception.message = exception.message + ': ' + response[:error][:message] % response[:error][:parameters] + ' request_id: ' + request_id
         rescue JSON::ParserError # rubocop:disable Lint/HandleExceptions
         end
         exception

--- a/spec/unit/core/connection_spec.rb
+++ b/spec/unit/core/connection_spec.rb
@@ -21,6 +21,7 @@ describe GoodData::Rest::Connection do
             }
         }.to_json
       }
+      allow(request_error).to receive(:headers) { { x_gdc_request: request_id } }
     end
     it 'enriches the exception' do
       expect(exception).to receive(:message=).with("StandardError: Checking 'project', result STRUCTURE INVALID request_id: random_request_id_string")


### PR DESCRIPTION
Sometimes the field response[:error][:requestId]
is not in the body of the response. This commit makes
the method pass even if there is no request id
In addition, it takes the request id from headers
which seems to be more reliable.