### PR TITLE
TMA-1502: use numeric user-id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN groupadd -g 1003 updater && \
     mkhomedir_helper updater && \
     chown updater: /home && \
     chown updater: /src
-USER updater
+USER 1003
 
 RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN curl -sSL https://get.rvm.io | bash -s stable


### PR DESCRIPTION
for docker does not operate properly with user-name