### PR TITLE
TMA-1502: remove jdk8 from tavis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -274,7 +274,6 @@ jobs:
     script: bundle exec rake test:unit
     os: osx
     rvm: jruby-9.1.14
-    jdk: openjdk8
 
   - stage: gem-release
     name: deploy MRI gem


### PR DESCRIPTION
return to inocence, for unknown reason openjdk8 and default mac-osx image does not work together on travis