### PR TITLE
II-371: Handle multitple configuration files

### DIFF
--- a/.gdc-ii-config.yaml
+++ b/.gdc-ii-config.yaml
@@ -15,3 +15,7 @@ integratedTests:
     repo_mount_dir: /src
     microservices:
       - lcm-bricks
+
+configFilesForUpdate:
+  - '.gdc-ii-config.yaml'
+  - '.gdc-ii-config-chart.yaml'


### PR DESCRIPTION
There is an update logic which finds the images/charts from multiple config files in repository.

It has to be set in repository, there is no impact of this change now (but it may happen in future that
some other image will be build in additional config).