### PR TITLE
CONFIG: TMA-1555 Separate test results for sdk and project test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -201,6 +201,8 @@ namespace :test do
   desc 'Run integration tests'
   RSpec::Core::RakeTask.new(:sdk) do |t|
     t.pattern = 'spec/integration/**/*.rb'
+    t.rspec_opts = '--color --format documentation --require spec_helper \
+    --format RspecJunitFormatter --out integration.results.xml'
   end
 
   desc 'Run LCM tests'
@@ -212,6 +214,8 @@ namespace :test do
        'it is possible to save time by running the tasks in parallel.'
   RSpec::Core::RakeTask.new(:project) do |t|
     t.pattern = 'spec/project/**/*.rb'
+    t.rspec_opts = '--color --format documentation --require spec_helper \
+    --format RspecJunitFormatter --out project.results.xml'
   end
 
   desc 'Run coding style tests'


### PR DESCRIPTION
Integration test invokes two rake tasks - sdk and project,
but the result was written to the same junit.xml file
so the second execution will overwrite the first one

Now integration test will generate separate test results for
these two rake tasks