### PR TITLE
II-603: Start using new NGVault secret paths

### DIFF
--- a/.gdc-ii-config.yaml
+++ b/.gdc-ii-config.yaml
@@ -10,7 +10,7 @@ integratedTests:
     env: bash
     path: .
     vault:
-      GD_SPEC_PASSWORD: ruby/test/bia_encryption_key
+      GD_SPEC_PASSWORD: "$VAULT_SPECIAL_PREFIX/ruby-test-bia-encryption-key"
     command: ./bin/run_smoke_tests.sh
     image: harbor.intgdc.com/staging/lcm-bricks:GIT_REV
     repo_mount_dir: /src


### PR DESCRIPTION
Vault prefix should now be part of the secret path.