### PR TITLE
Allow gooddata-ruby to be installed on rails 5.2/6.0

### DIFF
--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'sqlite3' if RUBY_PLATFORM != 'java'
 
-  s.add_dependency 'activesupport', '> 4.2.9', '< 6.0'
+  s.add_dependency 'activesupport', '> 4.2.9', '< 6.1'
 
   s.add_dependency 'aws-sdk-s3', '~> 1.16'
   s.add_dependency 'docile', '~> 1.1'

--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'sqlite3' if RUBY_PLATFORM != 'java'
 
-  s.add_dependency 'activesupport', '> 4.2.9', '< 5.2'
+  s.add_dependency 'activesupport', '> 4.2.9', '< 6.0'
 
   s.add_dependency 'aws-sdk-s3', '~> 1.16'
   s.add_dependency 'docile', '~> 1.1'


### PR DESCRIPTION
Hi there,

Rails 5.2 is out for a while. Locking gooddata to < 5.2 makes it impossible to use newer Rails versions.

We also plan to reach Rails 6.0 soon, so, it would be even better to remove the 'upper' restriction from activesupport on this gem, or at least having it on '< 6.1'. Thoughts?