### PR TITLE
Update image gdc-java-8-jre to 0dec94a (from gdc-docker-images)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.intgdc.com/tools/gdc-java-8-jre:d0f5e08
+FROM harbor.intgdc.com/tools/gdc-java-8-jre:0dec94a
 
 ARG RVM_VERSION=stable
 ARG JRUBY_VERSION=9.2.5.0
@@ -6,7 +6,7 @@ ARG JRUBY_VERSION=9.2.5.0
 LABEL image_name="GDC LCM Bricks"
 LABEL maintainer="LCM <lcm@gooddata.com>"
 LABEL git_repository_url="https://github.com/gooddata/gooddata-ruby/"
-LABEL parent_image="harbor.intgdc.com/tools/gdc-java-8-jre:d0f5e08"
+LABEL parent_image="harbor.intgdc.com/tools/gdc-java-8-jre:0dec94a"
 
 # which is required by RVM
 RUN yum install -y curl which patch make git \


### PR DESCRIPTION

Change HEAD: https://github.com/gooddata/gdc-docker-images/commit/0dec94a
Pipeline run: [gdc-docker-images/gdc-docker-images-tools-build-pipeline](https://jenkins-ii.intgdc.com/job/gdc-docker-images/job/gdc-docker-images-tools-build-pipeline/52/display/redirect)
