### PR TITLE
TRIVIAL: Temporarily remove perf out of test environment of LcmBuildPipeline

### DIFF
--- a/.gdc-ii-config.yaml
+++ b/.gdc-ii-config.yaml
@@ -20,3 +20,6 @@ integratedTests:
 configFilesForUpdate:
   - '.gdc-ii-config.yaml'
   - '.gdc-ii-config-chart.yaml'
+
+customConstants:
+  pipeline.deploy.testEnvironments: ['stg3', 'stg2', 'stg']


### PR DESCRIPTION
Currently, MSF has not redeployed k8s intances in Perf cluster yet.