### PR TITLE
CONFIG: MSF-18373 Remove customConstants for lcm pipeline

### DIFF
--- a/.gdc-ii-config.yaml
+++ b/.gdc-ii-config.yaml
@@ -20,6 +20,3 @@ integratedTests:
 configFilesForUpdate:
   - '.gdc-ii-config.yaml'
   - '.gdc-ii-config-chart.yaml'
-
-customConstants:
-  pipeline.deploy.testEnvironments: ['stg3', 'stg2', 'stg']


### PR DESCRIPTION
Last time we use a customConstants to remove perf cluster from
test evironment because perf was not available.
Now delete the customConstants part and use the one specified in
constants.yaml in chart-configs repo