### PR TITLE
Allow gooddata-ruby to be used with Rails 6.1

### DIFF
--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3' if RUBY_PLATFORM != 'java'
 
   if RUBY_VERSION >= '2.5'
-    s.add_dependency 'activesupport', '>= 6.0.3.1', '< 6.1'
+    s.add_dependency 'activesupport', '>= 6.0.3.1', '< 6.2'
   else
     s.add_dependency 'activesupport', '>= 5.2.4.3', '< 6.0'
   end

--- a/lib/gooddata.rb
+++ b/lib/gooddata.rb
@@ -37,3 +37,5 @@ require 'backports/2.1.0/array/to_h'
 
 # Helpers
 require 'gooddata/helpers/global_helpers'
+
+require 'active_support/core_ext/hash/compact' unless RUBY_VERSION >= '2.5'

--- a/lib/gooddata/lcm/actions/base_action.rb
+++ b/lib/gooddata/lcm/actions/base_action.rb
@@ -8,8 +8,6 @@ require 'gooddata/extensions/integer'
 require 'gooddata/extensions/string'
 require 'gooddata/extensions/nil'
 
-require 'active_support/core_ext/hash/compact'
-
 require_relative '../dsl/dsl'
 require_relative '../helpers/helpers'
 require_relative '../types/types'

--- a/lib/gooddata/lcm/lcm2.rb
+++ b/lib/gooddata/lcm/lcm2.rb
@@ -13,8 +13,6 @@ require 'gooddata/extensions/integer'
 require 'gooddata/extensions/string'
 require 'gooddata/extensions/nil'
 
-require 'active_support/core_ext/hash/compact'
-
 require_relative 'actions/actions'
 require_relative 'dsl/dsl'
 require_relative 'helpers/helpers'

--- a/lib/gooddata/lcm/types/base_type.rb
+++ b/lib/gooddata/lcm/types/base_type.rb
@@ -8,8 +8,6 @@
 require_relative '../dsl/dsl'
 require_relative '../helpers/helpers'
 
-require 'active_support/core_ext/hash/compact'
-
 require 'gooddata/extensions/class'
 
 module GoodData

--- a/lib/gooddata/models/blueprint/project_blueprint.rb
+++ b/lib/gooddata/models/blueprint/project_blueprint.rb
@@ -2,8 +2,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-require 'active_support/core_ext/hash/compact'
-
 module GoodData
   module Model
     class ProjectBlueprint

--- a/lib/gooddata/models/domain.rb
+++ b/lib/gooddata/models/domain.rb
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 require 'cgi'
-require 'active_support/core_ext/hash/compact'
 
 require_relative 'profile'
 require_relative '../extensions/enumerable'

--- a/lib/gooddata/models/project.rb
+++ b/lib/gooddata/models/project.rb
@@ -13,7 +13,6 @@ require 'zip'
 require 'net/smtp'
 
 require 'active_support/core_ext/hash/except'
-require 'active_support/core_ext/hash/compact'
 require 'active_support/core_ext/hash/slice'
 
 require_relative '../exceptions/no_project_error'

--- a/lib/gooddata/models/user_filters/user_filter_builder.rb
+++ b/lib/gooddata/models/user_filters/user_filter_builder.rb
@@ -7,7 +7,6 @@
 require_relative '../project_log_formatter'
 
 require 'active_support/core_ext/hash/indifferent_access'
-require 'active_support/core_ext/hash/compact'
 
 require 'gooddata/extensions/true'
 require 'gooddata/extensions/false'

--- a/lib/gooddata/models/user_group.rb
+++ b/lib/gooddata/models/user_group.rb
@@ -13,7 +13,6 @@ require_relative '../mixins/rest_resource'
 require_relative '../mixins/uri_getter'
 
 require 'active_support/core_ext/hash/except'
-require 'active_support/core_ext/hash/compact'
 
 module GoodData
   # Representation of User Group


### PR DESCRIPTION
Hi there 🙌 

We're preparing for upgrading our app to Rails 6.1 and found out that GoodData-ruby does not allow it yet. So, on this patch, we allow activesupport 6.1 to be installed and its compatibility.

Requiring `active_support/core_ext/hash/compact` on Rails 6.1 causes an error. Also shouldn't be needed for Ruby 2.5+. Check https://github.com/rails/rails/blob/6-0-stable/activesupport/lib/active_support/core_ext/hash/compact.rb  

I've tried running specs locally.. but most of them are not running because they are trying to hit your staging servers. So I'm not sure.. if this is all the work needed! 