### PR TITLE
BUGFIX: TMA-1714 Fixed failed delete master project related to staging3 - lcm user provisioning tests

### DIFF
--- a/spec/lcm/userprov/users_brick_spec.rb
+++ b/spec/lcm/userprov/users_brick_spec.rb
@@ -181,6 +181,7 @@ describe 'UsersBrick' do
       end
 
       after do
+        @segment && @segment.delete(force: true)
         @master_project.delete if @master_project
       end
     end


### PR DESCRIPTION
We should be delete segment first and then master project of 'adds users to project' test