### PR TITLE
BUGFIX: MSF-20827 Fix gem-smoke-test failed when release ruby SDK

### DIFF
--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -61,7 +61,11 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'aws-sdk-s3', '~> 1.16'
-  s.add_dependency 'docile', '~> 1.1'
+  if RUBY_VERSION >= '2.5'
+    s.add_dependency 'docile', '~> 1.1'
+  else
+    s.add_dependency 'docile', '> 1.1', '< 1.4.0'
+  end
   s.add_dependency 'gli', '~> 2.15'
   s.add_dependency 'gooddata_datawarehouse', '~> 0.0.10' if RUBY_PLATFORM == 'java'
   s.add_dependency 'highline', '= 2.0.0.pre.develop.14'


### PR DESCRIPTION
The latest docile 1.4.0 version require Ruby version >= 2.5.0. So It made failed gem-smoke-test when using Ruby 2.3.8 during running test. To fixing, we will check using latest docile file if the test running by Ruby version >= 2.5.0 otherwise using docile version < 1.4.0