### PR TITLE
chore(ci): avoid full-depth checkouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,7 @@ jobs:
   jruby-gem-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: jruby-9.4.1
@@ -29,9 +27,7 @@ jobs:
   rubygems-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.1
@@ -47,9 +43,7 @@ jobs:
       matrix:
         ruby-version: [3.2.1, jruby-9.4.1]
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,8 +14,6 @@ jobs:
       changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v40

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -17,8 +17,6 @@ jobs:
       changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v40

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -11,9 +11,7 @@ jobs:
       matrix:
         ruby-version: [2.5, 2.6, 2.7.6, 3.2.1, jruby-9.2.21, jruby-9.3.14, jruby-9.4.1]
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
@@ -24,9 +22,7 @@ jobs:
   pronto-code-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2

--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -80,6 +80,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json_pure', '~> 2.6'
   s.add_dependency 'multi_json', '~> 1.12'
   s.add_dependency 'parseconfig', '~> 1.0'
+  s.add_dependency 'path_expander', '< 1.1.2'
   s.add_dependency 'pmap', '~> 1.1'
   s.add_dependency 'sequel', '< 5.72.0'
   s.add_dependency 'remote_syslog_logger', '~> 1.0.3'


### PR DESCRIPTION
The repo is quite large and full-checkout often timeouts