### PR TITLE
GRIF-716.2: Add workflow_dispatch for promoting bricks stable tag

### DIFF
--- a/.github/workflows/lcm-pipeline.yaml
+++ b/.github/workflows/lcm-pipeline.yaml
@@ -303,13 +303,28 @@ jobs:
             --repo ${{ github.repository }} \
             --body "## LCM bricks image available
 
-          New image \`stable/lcm-bricks\` available and tagged for all prod clusters.
-          Please, manually run the respective rundeck job for each: ${{ secrets.RUNDECK_URL }}
+          New image \`stable/lcm-bricks\` is available.
 
           | | |
           |---|---|
           | **Version** | \`${{ needs.prepare-build.outputs.service_version }}\` |
-          | **Build tag** | \`${{ needs.prepare-build.outputs.image_tag }}\` |"
+          | **Build tag** | \`${{ needs.prepare-build.outputs.image_tag }}\` |
+
+          ### Next steps
+
+          **1. Tag the image with its major version**
+          Run the [LCM: Retag stable image to major version](${{ github.server_url }}/${{ github.repository }}/actions/workflows/lcm-stable-retag.yaml) workflow dispatch:
+          - Go to **Actions → LCM: Retag stable image to major version → Run workflow**
+          - Set **tag** to \`${{ needs.prepare-build.outputs.service_version }}\`
+          - Leave **dry-run** unchecked and click **Run workflow**
+
+          Or via gh CLI:
+          \`\`\`
+          gh workflow run lcm-stable-retag.yaml --repo ${{ github.repository }} -f tag=${{ needs.prepare-build.outputs.service_version }} -f dry-run=false
+          \`\`\`
+
+          **2. Register bricks to prod clusters**
+          Once the retag completes, manually run the respective Rundeck job for each cluster: ${{ secrets.RUNDECK_URL }}"
         env:
           GH_TOKEN: ${{ secrets.TOKEN_GITHUB_YENKINS }}
 

--- a/.github/workflows/lcm-stable-retag.yaml
+++ b/.github/workflows/lcm-stable-retag.yaml
@@ -1,0 +1,96 @@
+name: "LCM: Retag stable image to major version"
+run-name: "Retag stable lcm-bricks ${{ inputs.tag }} → M<major>-<cluster>"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Stable image tag to retag (e.g. 3.7.106)'
+        required: true
+        type: string
+      dry-run:
+        description: 'Dry-run only — print crane commands without executing'
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  retag-stable:
+    name: Retag stable/${{ inputs.tag }} to major version
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-small
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      INFRA_REPO_URL: ${{ secrets.ECR_URL }}
+      images: "lcm-bricks lcm-bricks-nextversion"
+      clusters: "na1 ca2 perf1 bom1 syd1 na3 eu1 fra1"
+    steps:
+      - name: Get required Vault secrets
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ secrets.VAULT_ADDRESS }}
+          method: jwt
+          path: jwt/github
+          role: ecr-push
+          secrets: |
+            secret/data/v3/int/ecr/infra1-user-ecr-rw aws_ecr_access_key | AWS_ACCESS_KEY ;
+            secret/data/v3/int/ecr/infra1-user-ecr-rw aws_ecr_secret_key | AWS_SECRET_KEY ;
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
+
+      - name: Retag images
+        env:
+          TAG: ${{ inputs.tag }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          major=$(echo "$TAG" | cut -d. -f1)
+          images=( ${{ env.images }} )
+          clusters=( ${{ env.clusters }} )
+          for image in "${images[@]}"; do
+            src="${INFRA_REPO_URL}/stable/${image}:${TAG}"
+            for cluster in "${clusters[@]}"; do
+              major_tag="M${major}-${cluster}"
+              if [ "${DRY_RUN}" == 'true' ]; then
+                echo "[dry-run] crane tag ${src} ${major_tag}"
+              else
+                crane tag "${src}" "${major_tag}"
+                echo "Tagged ${image}:${TAG} → ${image}:${major_tag}"
+              fi
+            done
+          done
+
+      - name: Summary
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          major=$(echo "$TAG" | cut -d. -f1)
+          clusters=( ${{ env.clusters }} )
+          {
+            echo "## LCM stable retag"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Source tag** | \`${TAG}\` |"
+            echo "| **Major tag pattern** | \`M${major}-<cluster>\` |"
+            echo "| **Clusters** | \`${clusters[*]}\` |"
+            echo "| **Dry-run** | \`${{ inputs.dry-run }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This PR:
- adds gh action `workflow_dispatch` for manually promoting a desired brick lcm tag to the one to be used (`Mn` where `n` is an int > 0)
- updated `lcm_pipeliene` to let the user know about the manual dispatch needed for release once a PR with `Version` update is merged