### PR TITLE
feat(logger): GDC_LOGGING_APPENDER=CONSOLE routes splunk channel to stdout

### DIFF
--- a/lib/gooddata/bricks/middleware/logger_middleware.rb
+++ b/lib/gooddata/bricks/middleware/logger_middleware.rb
@@ -53,9 +53,14 @@ module GoodData
 
         unless params['NO_SPLUNK_LOGGING'] && params['NO_SPLUNK_LOGGING'].to_b
           GoodData.logger.info "Statistics collecting is turned ON. All the data is anonymous."
-          # NODE_NAME is set up by k8s execmgr
-          syslog_node = ENV['NODE_NAME']
-          splunk_file_logger = syslog_node ? RemoteSyslogLogger.new(syslog_node, 514, program: "lcm_ruby_brick", facility: 'local2') : Logger.new(STDOUT)
+          logging_appender = ENV['GDC_LOGGING_APPENDER'] || 'SYSLOG'
+          splunk_file_logger = if logging_appender == 'CONSOLE'
+                                 Logger.new(STDOUT)
+                               else
+                                 # NODE_NAME is set up by k8s execmgr
+                                 syslog_node = ENV['NODE_NAME']
+                                 syslog_node ? RemoteSyslogLogger.new(syslog_node, 514, program: "lcm_ruby_brick", facility: 'local2') : Logger.new(STDOUT)
+                               end
           splunk_logger = SplunkLoggerDecorator.new splunk_file_logger
           splunk_logger.level = params['SPLUNK_LOG_LEVEL'] || GoodData::DEFAULT_SPLUNKLOG_LEVEL
           splunk_logger = splunk_logger.extend(ContextLoggerDecorator)

--- a/spec/unit/bricks/middleware/logger_middleware_spec.rb
+++ b/spec/unit/bricks/middleware/logger_middleware_spec.rb
@@ -100,6 +100,46 @@ describe GoodData::Bricks::LoggerMiddleware do
     end
   end
 
+  context 'when GDC_LOGGING_APPENDER is CONSOLE' do
+    let(:params) { { it_does: 'not matter' } }
+
+    around do |example|
+      original_appender = ENV['GDC_LOGGING_APPENDER']
+      ENV['GDC_LOGGING_APPENDER'] = 'CONSOLE'
+      example.run
+      ENV['GDC_LOGGING_APPENDER'] = original_appender
+    end
+
+    it 'does not create a remote syslog forwarder' do
+      ENV['NODE_NAME'] = '12.12.12.12'
+      expect(RemoteSyslogLogger).not_to receive(:new)
+      subject.call(params)
+    end
+
+    it 'still registers the splunk logger channel' do
+      expect(GoodData).to receive(:splunk_logging_on).with(splunk_logger)
+      subject.call(params)
+    end
+  end
+
+  context 'when GDC_LOGGING_APPENDER is SYSLOG' do
+    let(:params) { { it_does: 'not matter' } }
+    let(:node_name) { '12.12.12.12' }
+
+    around do |example|
+      original_appender = ENV['GDC_LOGGING_APPENDER']
+      ENV['GDC_LOGGING_APPENDER'] = 'SYSLOG'
+      example.run
+      ENV['GDC_LOGGING_APPENDER'] = original_appender
+    end
+
+    it 'creates a remote syslog forwarder' do
+      ENV['NODE_NAME'] = node_name
+      expect(RemoteSyslogLogger).to receive(:new).with(node_name, 514, program: 'lcm_ruby_brick', facility: 'local2')
+      subject.call(params)
+    end
+  end
+
   context 'GDC_LOG_LEVEL' do
     let(:params) { { 'GDC_LOG_LEVEL' => log_level } }
 


### PR DESCRIPTION
## Summary

- When `GDC_LOGGING_APPENDER=CONSOLE` is set, the brick's splunk-shaped log channel writes to STDOUT instead of constructing a `RemoteSyslogLogger` to `NODE_NAME:514`.
- Default `SYSLOG` preserves the existing behavior — no regression risk for clusters that don't opt in.
- Mirrors the appender pattern adopted by Bear webapp services in [gdc-webapp-microservices#1099](https://github.com/gooddata/gdc-webapp-microservices/pull/1099) so Alloy can scrape pod stdout natively into Loki, removing the host rsyslog → `/mnt/log/gdc-ruby` hop.

JIRA: [GRIF-233](https://gooddata.atlassian.net/browse/GRIF-233)

## Pairs with

[gooddata/msf#6503](https://github.com/gooddata/msf/pull/6503) — `execmgr-k8s` change that forwards `gdc.logging.appender` as the `GDC_LOGGING_APPENDER` env var on every brick K8s Job. Both PRs need to land for the appender to flip end-to-end.

## Test plan

- [ ] `bundle exec rspec spec/unit/bricks/middleware/logger_middleware_spec.rb` — green locally (13 examples, 0 failures, including 3 new ones: CONSOLE skips RemoteSyslogLogger, CONSOLE still registers splunk channel, explicit SYSLOG creates the syslog forwarder)
- [ ] After the paired MSF PR merges and a staging cluster sets `gdc.logging.appender=CONSOLE`, trigger one LCM brick and confirm output appears in Loki under `{sourcetype="console-log", container=~".*brick.*"} |= "action="` with the same `brick=…, action=…, execution_id=…` key=value body that today appears under `sourcetype="ruby"`.

[GRIF-233]: https://gooddata.atlassian.net/browse/GRIF-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ