### PR TITLE
fix(lcm): assure latest tag matches retagged ones

### DIFF
--- a/.github/workflows/lcm-stable-retag.yaml
+++ b/.github/workflows/lcm-stable-retag.yaml
@@ -64,17 +64,21 @@ jobs:
           major=$(echo "$TAG" | cut -d. -f1)
           images=( ${{ env.images }} )
           clusters=( ${{ env.clusters }} )
+          crane_tag() {
+            local src=$1 tag=$2
+            if [ "${DRY_RUN}" == 'true' ]; then
+              echo "[dry-run] crane tag ${src} ${tag}"
+            else
+              crane tag "${src}" "${tag}"
+              echo "Tagged ${src} → ${tag}"
+            fi
+          }
           for image in "${images[@]}"; do
             src="${INFRA_REPO_URL}/stable/${image}:${TAG}"
             for cluster in "${clusters[@]}"; do
-              major_tag="M${major}-${cluster}"
-              if [ "${DRY_RUN}" == 'true' ]; then
-                echo "[dry-run] crane tag ${src} ${major_tag}"
-              else
-                crane tag "${src}" "${major_tag}"
-                echo "Tagged ${image}:${TAG} → ${image}:${major_tag}"
-              fi
+              crane_tag "${src}" "M${major}-${cluster}"
             done
+            crane_tag "${src}" latest
           done
 
       - name: Summary


### PR DESCRIPTION
This PR adds assures `latest` for new retagged imgs and simplifies the logic a bit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image retagging now also updates the `latest` tag during the retagging process, even in dry-run mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->