### PR TITLE
fix(lcm): Add retry with refresh token during upload file

### DIFF
--- a/lib/gooddata/rest/connection.rb
+++ b/lib/gooddata/rest/connection.rb
@@ -527,14 +527,22 @@ module GoodData
       def do_stream_file(uri, filename, _options = {})
         GoodData.logger.info "Uploading file user storage #{uri}"
 
-        request = RestClient::Request.new(:method => :put,
-                                          :url => uri.to_s,
-                                          :verify_ssl => verify_ssl,
-                                          :headers => @webdav_headers.merge(:x_gdc_authtt => headers[:x_gdc_authtt]),
-                                          :payload => File.new(filename, 'rb'))
+        # Build the request inside the retryable block so that, after a token
+        # refresh triggered by a 401, the new x_gdc_authtt header is picked up
+        # and a fresh file handle is used for the retried upload.
+        b = proc do
+          request = RestClient::Request.new(:method => :put,
+                                            :url => uri.to_s,
+                                            :verify_ssl => verify_ssl,
+                                            :headers => @webdav_headers.merge(:x_gdc_authtt => headers[:x_gdc_authtt]),
+                                            :payload => File.new(filename, 'rb'))
+          request.execute
+        end
 
         begin
-          request.execute
+          GoodData::Rest::Connection.retryable(:tries => Helpers::GD_MAX_RETRY, :refresh_token => proc { refresh_token }) do
+            b.call
+          end
         rescue => e
           raise "Error when uploading file #{filename}. Error: #{e}"
         end

--- a/spec/project/full_process_schedule_spec.rb
+++ b/spec/project/full_process_schedule_spec.rb
@@ -228,7 +228,7 @@ describe "Full process and schedule exercise", :vcr, :constraint => 'slow' do
     end
   end
 
-  xit "should be possible to download deployed process" do
+  it "should be possible to download deployed process" do
     process = @project.deploy_process('./spec/data/hello_world_process/hello_world.zip',
                                       type: 'RUBY',
                                       name: 'Test ETL zipped file Process')


### PR DESCRIPTION
JIRA: GRIF-877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload retry behavior so uploads recover correctly after authentication refreshes and use a fresh file handle on retry.
  * Fixed an issue that could affect retried uploads during authorization failures.

* **Tests**
  * Enabled a previously skipped test covering download and decompression of deployed process artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->