### PR TITLE
ci: add extra cluster input on retagging to stable workflow

### DIFF
--- a/.github/workflows/lcm-stable-retag.yaml
+++ b/.github/workflows/lcm-stable-retag.yaml
@@ -1,5 +1,5 @@
 name: "LCM: Retag stable image to major version"
-run-name: "Retag stable lcm-bricks ${{ inputs.tag }} → M<major>-<cluster>"
+run-name: "Retag stable lcm-bricks ${{ inputs.tag }} → M<major>-${{ inputs.cluster }}"
 
 on:
   workflow_dispatch:
@@ -8,6 +8,20 @@ on:
         description: 'Stable image tag to retag (e.g. 3.7.106)'
         required: true
         type: string
+      cluster:
+        description: 'Target cluster to retag image to it'
+        required: true
+        type: choice
+        options:
+          - "na1"
+          - "ca2"
+          - "perf1"
+          - "bom1"
+          - "syd1"
+          - "na3"
+          - "eu1"
+          - "fra1"
+          - "all-clusters"
       dry-run:
         description: 'Dry-run only — print crane commands without executing'
         required: true
@@ -59,11 +73,17 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
           DRY_RUN: ${{ inputs.dry-run }}
+          CLUSTER: ${{ inputs.cluster }}
         run: |
           set -euo pipefail
           major=$(echo "$TAG" | cut -d. -f1)
           images=( ${{ env.images }} )
           clusters=( ${{ env.clusters }} )
+          target_cluster="${CLUSTER}"
+          if [[ "${target_cluster}" != "all-clusters" && " ${clusters[*]} " != *" ${target_cluster} "* ]]; then
+            echo "::error::Unknown cluster '${target_cluster}'. Configured clusters: ${clusters[*]}"
+            exit 1
+          fi
           crane_tag() {
             local src=$1 tag=$2
             if [ "${DRY_RUN}" == 'true' ]; then
@@ -75,9 +95,13 @@ jobs:
           }
           for image in "${images[@]}"; do
             src="${INFRA_REPO_URL}/stable/${image}:${TAG}"
-            for cluster in "${clusters[@]}"; do
-              crane_tag "${src}" "M${major}-${cluster}"
-            done
+            if [[ "${target_cluster}" == "all-clusters" ]]; then
+              for cluster in "${clusters[@]}"; do
+                crane_tag "${src}" "M${major}-${cluster}"
+              done
+            else
+              crane_tag "${src}" "M${major}-${target_cluster}"
+            fi
             crane_tag "${src}" latest
           done
 


### PR DESCRIPTION
This PR adds missing `cluster` list on workflow that promotes tag to stable via retagging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a required cluster selection option when manually running the stable retagging workflow (with an “all clusters” choice).
  * Retagging now targets either the selected cluster or all configured clusters.

* **Improvements**
  * Added validation for the chosen cluster; unsupported selections now stop the run with an error.
  * Retag targeting behavior updates accordingly based on the selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->