### PR TITLE
fix(lcm): point stable latest at the promoted version digest

### DIFF
--- a/.github/workflows/promote-to-stable.yaml
+++ b/.github/workflows/promote-to-stable.yaml
@@ -48,17 +48,24 @@ jobs:
 
       - name: Promote images
         run: |
+          set -euo pipefail
           built_images='${{ inputs.images }}'
           tag=${{ inputs.image_tag }}
           for image in $(echo "$built_images" | jq -r '.[]'); do
             crane cp \
               "${INFRA_REPO_URL}/staging/${image}:${tag}" \
               "${INFRA_REPO_URL}/stable/${image}:${tag}"
-            crane cp \
-              "${INFRA_REPO_URL}/staging/${image}:latest" \
-              "${INFRA_REPO_URL}/stable/${image}:latest"
+            # latest must be the digest just promoted, not whatever staging:latest is now
+            crane tag "${INFRA_REPO_URL}/stable/${image}:${tag}" latest
 
-            echo "Promoted image ${image} to stable"
+            promoted=$(crane digest "${INFRA_REPO_URL}/stable/${image}:${tag}")
+            current=$(crane digest "${INFRA_REPO_URL}/stable/${image}:latest")
+            if [[ "${promoted}" != "${current}" ]]; then
+              echo "::error::stable/${image}:latest (${current}) != :${tag} (${promoted})"
+              exit 1
+            fi
+
+            echo "Promoted image ${image} to stable as ${tag} + latest"
           done
 
       - name: Promote charts


### PR DESCRIPTION
`stable/<image>:latest` was copied independently from `staging/<image>:latest`,

This PR tags latest from the stable version tag that was just promoted instead, so the two are the same manifest by construction, and assert the digests match before the step succeeds. Also add `set -euo pipefail` so a crane failure mid-loop fails the step rather than being masked by the loop's last command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image promotion reliability by promoting the specified version and assigning the stable `latest` tag from the same image digest.
  * Added verification to detect mismatched stable image tags and fail the promotion when inconsistencies occur.
  * Enhanced workflow error handling and success reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->