### PR TITLE
fix(lcm): bound error collections embedded in exception messages

### DIFF
--- a/lib/gooddata/models/user_filters/user_filter_builder.rb
+++ b/lib/gooddata/models/user_filters/user_filter_builder.rb
@@ -22,10 +22,18 @@ module GoodData
     @all_domain_users = {}
     @mutex = Mutex.new
 
-    # Cap on error entries embedded in a raised exception's message (and logged).
-    # Domain-wide syncs can produce one entry per user/value across a whole domain;
-    # stringifying the raw collection exhausts the JRuby heap (GRIF-951).
+    # Caps on error entries embedded in a raised exception's message (and logged).
+    # Domain-wide syncs can produce one entry per user/value across a whole domain,
+    # and a single entry can embed large value lists; stringifying the raw
+    # collection exhausts the JRuby heap (GRIF-951).
     MAX_ERRORS_IN_MESSAGE = 10
+    MAX_ERROR_ENTRY_CHARS = 1_000
+
+    # Renders a bounded sample of an error collection for logs and exception
+    # messages: caps both the number of entries and each entry's rendered size.
+    def self.bounded_error_sample(errors)
+      errors.take(MAX_ERRORS_IN_MESSAGE).map { |e| e.inspect.slice(0, MAX_ERROR_ENTRY_CHARS) }
+    end
 
     # Main Entry function. Gets values and processes them to get filters
     # that are suitable for other function to process.
@@ -493,7 +501,7 @@ module GoodData
         errors = errors.map do |e|
           e.merge(pid: project.pid)
         end
-        sample = errors.take(MAX_ERRORS_IN_MESSAGE)
+        sample = bounded_error_sample(errors)
         GoodData.logger.error("Maqlizing MUFs failed with #{errors.size} error(s). First #{sample.size}: #{sample.pretty_inspect}")
         fail GoodData::FilterMaqlizationError, "Maqlizing MUFs resulted in #{errors.size} error(s). First #{sample.size}: #{sample}"
       end
@@ -550,7 +558,7 @@ module GoodData
         project_log_formatter.log_user_filter_results(create_results, to_create)
         create_errors = create_results.select { |r| r[:status] == :failed }
         if create_errors.any?
-          sample = create_errors.take(MAX_ERRORS_IN_MESSAGE)
+          sample = bounded_error_sample(create_errors)
           GoodData.logger.error("Creating MUFs failed with #{create_errors.size} error(s). First #{sample.size}: #{sample.pretty_inspect}")
           fail "Creating MUFs resulted in errors, count: #{create_errors.size}, first #{sample.size}: #{sample}"
         end
@@ -587,7 +595,7 @@ module GoodData
           project_log_formatter.log_user_filter_results(delete_results, to_delete)
           delete_errors = delete_results.select { |r| r[:status] == :failed } if delete_results
           if delete_errors&.any?
-            sample = delete_errors.take(MAX_ERRORS_IN_MESSAGE)
+            sample = bounded_error_sample(delete_errors)
             GoodData.logger.error("Deleting MUFs failed with #{delete_errors.size} error(s). First #{sample.size}: #{sample.pretty_inspect}")
             fail "Deleting MUFs resulted in errors, count: #{delete_errors.size}, first #{sample.size}: #{sample}"
           end
@@ -659,7 +667,7 @@ module GoodData
                              end
 
       if !ignore_missing_values && !errors.empty?
-        sample = errors.take(MAX_ERRORS_IN_MESSAGE)
+        sample = bounded_error_sample(errors)
         GoodData.logger.error("Maqlizing variables failed with #{errors.size} error(s). First #{sample.size}: #{sample.pretty_inspect}")
         fail GoodData::FilterMaqlizationError, "Maqlizing variables resulted in #{errors.size} error(s). First #{sample.size}: #{sample}"
       end

--- a/lib/gooddata/models/user_filters/user_filter_builder.rb
+++ b/lib/gooddata/models/user_filters/user_filter_builder.rb
@@ -22,6 +22,11 @@ module GoodData
     @all_domain_users = {}
     @mutex = Mutex.new
 
+    # Cap on error entries embedded in a raised exception's message (and logged).
+    # Domain-wide syncs can produce one entry per user/value across a whole domain;
+    # stringifying the raw collection exhausts the JRuby heap (GRIF-951).
+    MAX_ERRORS_IN_MESSAGE = 10
+
     # Main Entry function. Gets values and processes them to get filters
     # that are suitable for other function to process.
     # Values can be read from file or provided inline as an array.
@@ -488,7 +493,9 @@ module GoodData
         errors = errors.map do |e|
           e.merge(pid: project.pid)
         end
-        fail GoodData::FilterMaqlizationError, errors
+        sample = errors.take(MAX_ERRORS_IN_MESSAGE)
+        GoodData.logger.error("Maqlizing MUFs failed with #{errors.size} error(s). First #{sample.size}: #{sample.pretty_inspect}")
+        fail GoodData::FilterMaqlizationError, "Maqlizing MUFs resulted in #{errors.size} error(s). First #{sample.size}: #{sample}"
       end
 
       filters = user_filters.map { |data| client.create(MandatoryUserFilter, data, project: project) }
@@ -542,7 +549,11 @@ module GoodData
         end
         project_log_formatter.log_user_filter_results(create_results, to_create)
         create_errors = create_results.select { |r| r[:status] == :failed }
-        fail "Creating MUFs resulted in errors: #{create_errors}" if create_errors.any?
+        if create_errors.any?
+          sample = create_errors.take(MAX_ERRORS_IN_MESSAGE)
+          GoodData.logger.error("Creating MUFs failed with #{create_errors.size} error(s). First #{sample.size}: #{sample.pretty_inspect}")
+          fail "Creating MUFs resulted in errors, count: #{create_errors.size}, first #{sample.size}: #{sample}"
+        end
       end
 
       if to_delete.empty?
@@ -575,7 +586,11 @@ module GoodData
 
           project_log_formatter.log_user_filter_results(delete_results, to_delete)
           delete_errors = delete_results.select { |r| r[:status] == :failed } if delete_results
-          fail "Deleting MUFs resulted in errors: #{delete_errors}" if delete_errors&.any?
+          if delete_errors&.any?
+            sample = delete_errors.take(MAX_ERRORS_IN_MESSAGE)
+            GoodData.logger.error("Deleting MUFs failed with #{delete_errors.size} error(s). First #{sample.size}: #{sample.pretty_inspect}")
+            fail "Deleting MUFs resulted in errors, count: #{delete_errors.size}, first #{sample.size}: #{sample}"
+          end
         end
       end
 
@@ -643,7 +658,11 @@ module GoodData
                                maqlify_filters(filters, users, options.merge(users_cache: users_cache, users_must_exist: users_must_exist))
                              end
 
-      fail GoodData::FilterMaqlizationError, errors if !ignore_missing_values && !errors.empty?
+      if !ignore_missing_values && !errors.empty?
+        sample = errors.take(MAX_ERRORS_IN_MESSAGE)
+        GoodData.logger.error("Maqlizing variables failed with #{errors.size} error(s). First #{sample.size}: #{sample.pretty_inspect}")
+        fail GoodData::FilterMaqlizationError, "Maqlizing variables resulted in #{errors.size} error(s). First #{sample.size}: #{sample}"
+      end
       filters = user_filters.map { |data| client.create(klass, data, project: project) }
       resolve_user_filters(filters, project_filters)
     end

--- a/spec/unit/models/user_filters/user_filter_builder_spec.rb
+++ b/spec/unit/models/user_filters/user_filter_builder_spec.rb
@@ -213,6 +213,9 @@ describe GoodData::UserFilterBuilder do
       it 'raises an error with a message bounded to the first few errors' do
         expect { subject.execute_mufs(filter_definitions, options) }.to raise_error do |error|
           expect(error.message).to match(/Creating MUFs resulted in errors, count: 500, first 10/)
+          expect(error.message).to include('user0@example.com')
+          expect(error.message).to include('user9@example.com')
+          expect(error.message).not_to include('user10@example.com')
           expect(error.message.size).to be < 15_000
         end
       end

--- a/spec/unit/models/user_filters/user_filter_builder_spec.rb
+++ b/spec/unit/models/user_filters/user_filter_builder_spec.rb
@@ -199,5 +199,23 @@ describe GoodData::UserFilterBuilder do
         expect { subject.execute_mufs(filter_definitions, options) }.to raise_error(/Creating MUFs resulted in errors/)
       end
     end
+
+    context 'when creating MUFs results in a large number of errors' do
+      let(:failed_users) do
+        Array.new(500) { |i| { 'login' => "user#{i}@example.com", 'detail' => 'x' * 1_000 } }
+      end
+
+      before do
+        allow(client).to receive(:post)
+          .and_return 'userFiltersUpdateResult' => { 'failed' => failed_users }
+      end
+
+      it 'raises an error with a message bounded to the first few errors' do
+        expect { subject.execute_mufs(filter_definitions, options) }.to raise_error do |error|
+          expect(error.message).to match(/Creating MUFs resulted in errors, count: 500, first 10/)
+          expect(error.message.size).to be < 15_000
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why

`LcmJavaHeapSpaceError` fires ~50×/month on NA3 (GRIF-951): `java.lang.OutOfMemoryError: Java heap space` in the user_filters brick during `GoodData::LCM2::SynchronizeUserFilters`, with `RubyHash.inspect`/`RubyArray.inspect` frames in the stack trace.

Root cause: `UserFilterBuilder.execute_mufs` (and the variables path in `execute`) raise exceptions with the **raw error Array/Hash embedded as the message**:

```ruby
fail GoodData::FilterMaqlizationError, errors
fail "Creating MUFs resulted in errors: #{create_errors}"
```

Stringifying that collection runs `inspect` over up to one entry per user/value across an entire domain sync — and Ruby re-derives the string on **every** downstream `.message` / `"#{e}"` / `JSON.pretty_generate` call (4 such call sites via `lcm2.rb`, `run_brick.rb`, `execution_result_middleware.rb`). Measured: 200k error entries → **53.9 MB** message per derivation. Container memory bumps can't fix this (NA3 already went 4Gi→5Gi→6Gi with no effect).

## What

- Cap the exception message (and the logged error dump) to the first `MAX_ERRORS_IN_MESSAGE = 10` entries plus a total count, at all four raise sites — same pattern already used by `synchronize_users.rb`. Bounded message: ~3 KB.
- Test-asserted message prefixes (`Creating/Deleting MUFs resulted in errors`) are preserved.
- New regression test: 500 synthetic failed users → message stays bounded and reports `count: 500, first 10`.

## Notes for reviewers

- `FilterMaqlizationError` is a bare `RuntimeError`; the only consumers read `.message` (both in `spec/integration/user_filters_spec.rb`), and for ≤10 errors the message still contains the full detail, so those tests are unaffected.
- Pre-existing, out of scope: the delete-errors `fail` is currently dead code (since b7adb562 `delete_results` is nil inside its own defining block). The bounding here is defense-in-depth for when that gets fixed separately.

JIRA: GRIF-951

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xTbPyZxxECyx93VgEfW4p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented large error payloads from overwhelming memory when user filter operations fail.
  - Updated failure error messages to include the total failure count plus a limited, concise sampled subset.
  - Applied bounded, sampled error reporting consistently across filter maqlification, creation, deletion, and variable processing failures.
- **Tests**
  - Added coverage ensuring large batches of failures produce bounded error messages (including sampling behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->